### PR TITLE
test: リファクタリング Phase 1 — テスト安全網の構築 (D-1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run pytest
+        run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ elastic-kernel = "elastic_kernel.command:main"
 [tool.setuptools.packages.find]
 where = ["."]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.setuptools.package-data]
 "elastic_kernel" = ["kernel.json", "kernel.py"]
 
@@ -62,6 +65,7 @@ dev = [
     "flake8>=5.0.4",
     "isort>=5.13.2",
     "mypy>=1.14.1",
+    "pytest>=8.3.5",
     "twine>=6.1.0",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures for the ElasticKernel test suite.
+
+These tests pin the *current* behavior of the codebase as a safety net for
+refactoring (see docs/prompts/refactor-instructions.md, Phase 1). They must not
+change production code.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def fake_shell():
+    """A minimal stand-in for ZMQInteractiveShell.
+
+    find_input_vars / migrate only ever touch ``shell.user_ns``, so a
+    SimpleNamespace with a ``user_ns`` dict is sufficient.
+    """
+
+    def _make(user_ns=None):
+        return SimpleNamespace(user_ns=dict(user_ns or {}))
+
+    return _make
+
+
+@pytest.fixture
+def profile_dict():
+    """The mutable profiling dict that fingerprint functions accumulate into."""
+    return {"idgraph": 0.0, "representation": 0.0}

--- a/tests/test_checkpoint_file.py
+++ b/tests/test_checkpoint_file.py
@@ -1,0 +1,43 @@
+"""Tests for the CheckpointFile builder (set/get round-trip)."""
+
+from elastic_notebook.core.common.checkpoint_file import CheckpointFile
+from elastic_notebook.core.graph.graph import DependencyGraph
+
+
+def test_builder_sets_and_gets_all_fields():
+    graph = DependencyGraph()
+    variables = {"a": [1]}
+    vss_migrate = {"vs1"}
+    vss_recompute = {"vs2"}
+    ces_recompute = {"ce1"}
+    recomputation_ces = {"ce1": {"ce0"}}
+    serialization_order = [["vs1"]]
+    udfs = {"f"}
+
+    cf = (
+        CheckpointFile()
+        .with_dependency_graph(graph)
+        .with_variables(variables)
+        .with_vss_to_migrate(vss_migrate)
+        .with_vss_to_recompute(vss_recompute)
+        .with_ces_to_recompute(ces_recompute)
+        .with_recomputation_ces(recomputation_ces)
+        .with_serialization_order(serialization_order)
+        .with_udfs(udfs)
+    )
+
+    assert cf.get_dependency_graph() is graph
+    assert cf.get_variables() == variables
+    assert cf.get_vss_to_migrate() == vss_migrate
+    assert cf.get_vss_to_recompute() == vss_recompute
+    assert cf.get_ces_to_recompute() == ces_recompute
+    assert cf.get_recomputation_ces() == recomputation_ces
+    assert cf.get_serialization_order() == serialization_order
+    assert cf.get_udfs() == udfs
+
+
+def test_defaults_are_none():
+    cf = CheckpointFile()
+    assert cf.get_dependency_graph() is None
+    assert cf.get_variables() is None
+    assert cf.get_udfs() is None

--- a/tests/test_find_input_vars.py
+++ b/tests/test_find_input_vars.py
@@ -1,0 +1,73 @@
+"""Tests for find_input_vars (AST-based input variable detection).
+
+Pins current behavior; do not change production code to satisfy these.
+"""
+
+from elastic_notebook.core.notebook.find_input_vars import find_input_vars
+
+
+def _udf_helper():
+    # Defined at module level so inspect.getsource() returns unindented source
+    # (as a real notebook-defined UDF would be).
+    return w + [0]  # noqa: F821 — `w` is resolved from user_ns at analysis time
+
+
+def test_simple_reference(fake_shell):
+    shell = fake_shell({"x": 1})
+    inputs, fdefs = find_input_vars("y = x + 1", {"x"}, shell, set())
+    assert inputs == {"x"}
+    assert fdefs == set()
+
+
+def test_assignment_target_is_not_input(fake_shell):
+    # The assignment target `y` is a Store, not a Load, so it is not an input.
+    shell = fake_shell({"x": 1})
+    inputs, _ = find_input_vars("y = x + 1", {"x"}, shell, set())
+    assert "y" not in inputs
+
+
+def test_input_filtered_by_existing_variables(fake_shell):
+    # `q` is read but is not an existing variable, so it is dropped.
+    shell = fake_shell({"x": 1})
+    inputs, _ = find_input_vars("z = x + q", {"x"}, shell, set())
+    assert inputs == {"x"}
+
+
+def test_aug_assign_counts_as_input(fake_shell):
+    shell = fake_shell({"x": 1})
+    inputs, _ = find_input_vars("x += 1", {"x"}, shell, set())
+    assert inputs == {"x"}
+
+
+def test_global_declaration_and_nonprimitive_local_read(fake_shell):
+    # Inside a function, a non-primitive name read from the namespace is still
+    # treated as an input; the `global` target is not.
+    shell = fake_shell({"x": [1, 2, 3]})
+    code = "def f():\n    global z\n    z = x\n"
+    inputs, fdefs = find_input_vars(code, {"x"}, shell, set())
+    assert inputs == {"x"}
+    assert fdefs == {"f"}
+
+
+def test_primitive_local_read_is_skipped(fake_shell):
+    # A primitive read in local scope (not declared global) is intentionally
+    # NOT counted as an input by the original ElasticNotebook heuristic.
+    shell = fake_shell({"x": 1})
+    code = "def f():\n    z = x\n    return z\n"
+    inputs, _ = find_input_vars(code, {"x"}, shell, set())
+    assert "x" not in inputs
+
+
+def test_function_def_is_reported(fake_shell):
+    shell = fake_shell({})
+    code = "def myfunc():\n    return 1\n"
+    inputs, fdefs = find_input_vars(code, set(), shell, set())
+    assert fdefs == {"myfunc"}
+
+
+def test_udf_recursion_finds_nested_input(fake_shell):
+    # The cell calls helper(); helper reads non-primitive `w`. The recursion
+    # into the UDF source should surface `w` as an input.
+    shell = fake_shell({"helper": _udf_helper, "w": [1, 2, 3]})
+    inputs, _ = find_input_vars("helper()", {"w", "helper"}, shell, {"helper"})
+    assert "w" in inputs

--- a/tests/test_find_output_vars.py
+++ b/tests/test_find_output_vars.py
@@ -1,0 +1,31 @@
+"""Tests for find_created_deleted_vars (namespace diffing)."""
+
+from elastic_notebook.core.notebook.find_output_vars import find_created_deleted_vars
+
+
+def test_created_variables():
+    created, deleted = find_created_deleted_vars({"x"}, {"x", "y", "z"})
+    assert created == {"y", "z"}
+    assert deleted == set()
+
+
+def test_deleted_variables():
+    created, deleted = find_created_deleted_vars({"x", "y"}, {"x"})
+    assert created == set()
+    assert deleted == {"y"}
+
+
+def test_underscore_names_excluded():
+    # Names beginning with '_' (e.g. IPython internals) are ignored in both
+    # the created and deleted sets.
+    created, deleted = find_created_deleted_vars(
+        {"_old", "keep"}, {"keep", "new", "_new"}
+    )
+    assert created == {"new"}
+    assert deleted == set()
+
+
+def test_no_change():
+    created, deleted = find_created_deleted_vars({"a", "b"}, {"a", "b"})
+    assert created == set()
+    assert deleted == set()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,59 @@
+"""Tests for DependencyGraph and update_graph."""
+
+from elastic_notebook.core.graph.graph import DependencyGraph
+from elastic_notebook.core.notebook.update_graph import update_graph
+
+
+def test_variable_snapshot_versioning():
+    g = DependencyGraph()
+    vs0 = g.create_variable_snapshot("x", False)
+    vs1 = g.create_variable_snapshot("x", False)
+    assert vs0.version == 0
+    assert vs1.version == 1
+    assert g.variable_snapshots["x"] == [vs0, vs1]
+
+
+def test_add_cell_execution_wires_edges():
+    g = DependencyGraph()
+    src = g.create_variable_snapshot("a", False)
+    dst = g.create_variable_snapshot("b", False)
+    g.add_cell_execution("b = a", 0.5, 0.0, {src}, {dst})
+
+    ce = g.cell_executions[0]
+    assert ce.cell_num == 0
+    assert ce in src.input_ces
+    assert dst.output_ce is ce
+
+
+def test_cell_num_increments():
+    g = DependencyGraph()
+    g.add_cell_execution("c1", 0.0, 0.0, set(), set())
+    g.add_cell_execution("c2", 0.0, 0.0, set(), set())
+    assert [ce.cell_num for ce in g.cell_executions] == [0, 1]
+
+
+def test_update_graph_connects_input_to_new_output():
+    g = DependencyGraph()
+    # Cell 0 creates x.
+    update_graph("x = 1", 0.1, 0.0, set(), {"x"}, set(), g)
+    # Cell 1 reads x and creates y.
+    update_graph("y = x", 0.1, 0.0, {"x"}, {"y"}, set(), g)
+
+    assert len(g.cell_executions) == 2
+    vs_x = g.variable_snapshots["x"][-1]
+    vs_y = g.variable_snapshots["y"][-1]
+    ce1 = g.cell_executions[1]
+
+    # The second CE depends on x and produces y.
+    assert ce1 in vs_x.input_ces
+    assert vs_y.output_ce is ce1
+
+
+def test_update_graph_deletion_marks_vs_deleted():
+    g = DependencyGraph()
+    update_graph("x = 1", 0.1, 0.0, set(), {"x"}, set(), g)
+    update_graph("del x", 0.1, 0.0, set(), set(), {"x"}, g)
+
+    # A new VS is created for the deletion, flagged as deleted.
+    deletion_vs = g.variable_snapshots["x"][-1]
+    assert deletion_vs.deleted is True

--- a/tests/test_id_graph.py
+++ b/tests/test_id_graph.py
@@ -1,0 +1,73 @@
+"""Tests for the ID graph (identity-structure tracking)."""
+
+from elastic_notebook.core.mutation.id_graph import (
+    construct_id_graph,
+    is_root_equals,
+    is_structure_equals,
+)
+
+
+def test_list_structure_equal_to_itself():
+    x = [1, 2, 3]
+    g1, ids1 = construct_id_graph(x)
+    g2, ids2 = construct_id_graph(x)
+    assert ids1 == ids2
+    assert is_structure_equals(g1, g2)
+    assert is_root_equals(g1, g2)
+
+
+def test_nested_list_ids_include_children():
+    inner = [1, 2]
+    outer = [inner]
+    _, ids = construct_id_graph(outer)
+    # Both the outer and the (non-primitive) inner list are reachable.
+    assert id(outer) in ids
+    assert id(inner) in ids
+
+
+def test_dict_keys_and_values_tracked():
+    k = (1, 2)  # non-primitive key (tuple)
+    v = [3, 4]  # non-primitive value
+    d = {k: v}
+    _, ids = construct_id_graph(d)
+    assert id(d) in ids
+    assert id(k) in ids
+    assert id(v) in ids
+
+
+def test_shared_reference_recorded_once():
+    shared = [0]
+    container = [shared, shared]
+    g, ids = construct_id_graph(container)
+    # The shared object appears once in the id set.
+    assert id(shared) in ids
+    # The two child nodes point at the same node object (cycle/shared handling).
+    assert g.child_nodes[0] is g.child_nodes[1]
+
+
+def test_cyclic_reference_terminates():
+    a = []
+    a.append(a)  # self-referential list
+    g, ids = construct_id_graph(a)
+    assert id(a) in ids
+    # The single child node is the node itself (handled via visited set).
+    assert g.child_nodes[0] is g
+
+
+def test_different_objects_not_root_equal():
+    # Keep both objects alive so CPython cannot reuse the first list's id for
+    # the second (which would make their root nodes compare equal).
+    a = [1, 2, 3]
+    b = [1, 2, 3]  # equal value, different identity
+    g1, _ = construct_id_graph(a)
+    g2, _ = construct_id_graph(b)
+    assert not is_root_equals(g1, g2)
+
+
+def test_none_graphs():
+    g_none, ids = construct_id_graph(None)
+    assert g_none is None
+    assert ids == set()
+    assert is_structure_equals(None, None)
+    assert is_root_equals(None, None)
+    assert not is_root_equals(None, construct_id_graph([1])[0])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,42 @@
+"""End-to-end integration test: record_event -> checkpoint -> load_checkpoint.
+
+Runs without a Jupyter server by driving a real IPython InteractiveShell
+directly. If the IPython shell cannot be constructed in this environment, the
+test skips (see docs/prompts/refactor-instructions.md Phase 1, step 3).
+"""
+
+import pytest
+
+pytest.importorskip("IPython")
+
+from IPython.core.interactiveshell import InteractiveShell  # noqa: E402
+
+from elastic_notebook.elastic_notebook import ElasticNotebook  # noqa: E402
+
+
+def _run_and_record(shell, en, code):
+    pre = set(shell.user_ns.keys())
+    shell.run_cell(code)
+    en.record_event(code, pre, 0.0, 0.1)
+
+
+def test_record_checkpoint_restore_round_trip(tmp_path):
+    try:
+        shell1 = InteractiveShell()
+    except Exception as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"Could not construct InteractiveShell: {exc}")
+
+    en1 = ElasticNotebook(shell1, str(tmp_path))
+    _run_and_record(shell1, en1, "x = 42")
+    _run_and_record(shell1, en1, "import numpy\na = numpy.arange(10)")
+
+    path = str(tmp_path / "checkpoint.pickle")
+    assert en1.checkpoint(path) is True
+
+    # Restore into a fresh shell/notebook.
+    shell2 = InteractiveShell()
+    en2 = ElasticNotebook(shell2, str(tmp_path))
+    en2.load_checkpoint(path)
+
+    assert shell2.user_ns["x"] == 42
+    assert list(shell2.user_ns["a"]) == list(range(10))

--- a/tests/test_migrate_resume.py
+++ b/tests/test_migrate_resume.py
@@ -1,0 +1,119 @@
+"""Round-trip tests for migrate() -> resume() and the fault-tolerance path.
+
+The checkpoint file format (dill: metadata, then one variable group per entry
+in serialization_order) must not change. These tests guard it.
+"""
+
+import dill
+import numpy as np
+
+from elastic_notebook.core.common.checkpoint_file import CheckpointFile
+from elastic_notebook.core.graph.graph import DependencyGraph
+from elastic_notebook.core.io.migrate import migrate
+from elastic_notebook.core.io.recover import resume
+
+
+def _flatten(variables):
+    """variables is {cell_num: [(vs, obj), ...]} -> {name: obj}."""
+    return {vs.name: obj for pairs in variables.values() for (vs, obj) in pairs}
+
+
+def test_migrate_resume_round_trip(fake_shell, tmp_path):
+    g = DependencyGraph()
+    vs_x = g.create_variable_snapshot("x", False)
+    vs_a = g.create_variable_snapshot("a", False)
+    g.add_cell_execution("x = 42; a = arange(3)", 0.1, 0.0, set(), {vs_x, vs_a})
+
+    shell = fake_shell({"x": 42, "a": np.arange(3)})
+    path = str(tmp_path / "checkpoint.pickle")
+
+    migrate(
+        graph=g,
+        shell=shell,
+        vss_to_migrate={vs_x, vs_a},
+        vss_to_recompute=set(),
+        ces_to_recompute=set(),
+        udfs={"foo"},
+        recomputation_ces={},
+        overlapping_vss=set(),
+        filename=path,
+    )
+
+    graph2, variables, ces_to_recompute, udfs = resume(path)
+
+    recovered = _flatten(variables)
+    assert recovered["x"] == 42
+    assert np.array_equal(recovered["a"], np.arange(3))
+    assert udfs == {"foo"}
+    assert ces_to_recompute == set()
+    assert isinstance(graph2, DependencyGraph)
+
+
+def test_resume_returns_ces_to_recompute_from_file(fake_shell, tmp_path):
+    # ces_to_recompute written to the checkpoint is returned on resume.
+    g = DependencyGraph()
+    vs_x = g.create_variable_snapshot("x", False)
+    g.add_cell_execution("x = 42", 0.1, 0.0, set(), {vs_x})
+    ce0 = g.cell_executions[0]
+
+    shell = fake_shell({"x": 42})
+    path = str(tmp_path / "checkpoint.pickle")
+
+    migrate(
+        graph=g,
+        shell=shell,
+        vss_to_migrate={vs_x},
+        vss_to_recompute=set(),
+        ces_to_recompute={ce0},
+        udfs=set(),
+        recomputation_ces={},
+        overlapping_vss=set(),
+        filename=path,
+    )
+
+    _, _, ces_to_recompute, _ = resume(path)
+    assert len(ces_to_recompute) == 1
+    assert next(iter(ces_to_recompute)).cell_num == 0
+
+
+def test_resume_tolerates_corrupt_variable_group(tmp_path):
+    """A variable group that fails to unpickle must not crash resume().
+
+    D-2: the current implementation re-reads the whole file at recover.py:53,
+    which OVERWRITES the in-memory metadata and therefore DISCARDS the
+    ces_to_recompute additions made in the except-branch. So the fault-tolerance
+    fallback is effectively a no-op today. This test pins that buggy behavior;
+    it must be flipped (ces_to_recompute should contain ce0) once D-2 is fixed
+    in Phase 4.
+    """
+    g = DependencyGraph()
+    vs_x = g.create_variable_snapshot("x", False)
+    g.add_cell_execution("x = 1", 0.1, 0.0, set(), {vs_x})
+    ce0 = g.cell_executions[0]
+
+    metadata = (
+        CheckpointFile()
+        .with_dependency_graph(g)
+        .with_variables({})
+        .with_vss_to_migrate({vs_x})
+        .with_vss_to_recompute(set())
+        .with_ces_to_recompute(set())
+        .with_recomputation_ces({ce0: {ce0}})
+        .with_serialization_order([[vs_x]])
+        .with_udfs(set())
+    )
+
+    path = tmp_path / "corrupt.pickle"
+    with open(path, "wb") as f:
+        dill.dump(metadata, f)
+        # Where the first variable group should be: write non-pickle garbage.
+        f.write(b"this is not a valid pickle stream")
+
+    # resume must not raise even though the variable group is unreadable.
+    _, variables, ces_to_recompute, _ = resume(str(path))
+
+    # No variables were recovered.
+    assert dict(variables) == {}
+    # D-2 (current/buggy): the recompute fallback is discarded by the re-read.
+    # Flip this assertion to `len(ces_to_recompute) == 1` after fixing D-2.
+    assert ces_to_recompute == set()

--- a/tests/test_object_hash.py
+++ b/tests/test_object_hash.py
@@ -1,0 +1,77 @@
+"""Tests for construct_object_hash and compare_fingerprint."""
+
+import numpy as np
+
+from elastic_notebook.core.mutation.fingerprint import (
+    compare_fingerprint,
+    construct_fingerprint,
+)
+from elastic_notebook.core.mutation.object_hash import (
+    ImmutableObj,
+    NpArrayObj,
+    construct_object_hash,
+)
+
+
+def test_none_hashes_to_immutable():
+    assert construct_object_hash(None) == ImmutableObj()
+
+
+def test_function_hashes_to_immutable():
+    def f():
+        return 1
+
+    assert construct_object_hash(f) == ImmutableObj()
+
+
+def test_primitive_hash_is_deterministic_and_distinct():
+    assert construct_object_hash(42) == construct_object_hash(42)
+    assert construct_object_hash(42) != construct_object_hash(43)
+
+
+def test_numpy_array_hash_equality():
+    a = np.array([1, 2, 3])
+    b = np.array([1, 2, 3])
+    c = np.array([1, 2, 4])
+    assert construct_object_hash(a) == construct_object_hash(b)
+    assert construct_object_hash(a) != construct_object_hash(c)
+    assert isinstance(construct_object_hash(a), NpArrayObj)
+
+
+def test_compare_fingerprint_no_change(profile_dict):
+    x = [1, 2, 3]
+    fp = construct_fingerprint(x, profile_dict)
+    changed, overwritten = compare_fingerprint(fp, x, profile_dict, set())
+    assert changed is False
+    assert overwritten is False
+
+
+def test_compare_fingerprint_inplace_modification(profile_dict):
+    # Appending mutates the same object -> changed but NOT overwritten.
+    x = [1, 2, 3]
+    fp = construct_fingerprint(x, profile_dict)
+    x.append(4)
+    changed, overwritten = compare_fingerprint(fp, x, profile_dict, set())
+    assert changed is True
+    assert overwritten is False
+
+
+def test_compare_fingerprint_overwrite(profile_dict):
+    # A brand-new object with a different identity -> overwritten.
+    x = [1, 2, 3]
+    fp = construct_fingerprint(x, profile_dict)
+    new_obj = [1, 2, 3, 4]
+    changed, overwritten = compare_fingerprint(fp, new_obj, profile_dict, set())
+    assert changed is True
+    assert overwritten is True
+
+
+def test_compare_fingerprint_numpy_inplace_value_change(profile_dict):
+    # Same array object, same structure, but a changed element value is caught
+    # via the object hash (changed, not overwritten).
+    a = np.array([1, 2, 3])
+    fp = construct_fingerprint(a, profile_dict)
+    a[0] = 99
+    changed, overwritten = compare_fingerprint(fp, a, profile_dict, set())
+    assert changed is True
+    assert overwritten is False

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,40 @@
+"""Tests for OptimizerExact.select_vss on small synthetic graphs.
+
+These pin the default checkpoint path's migrate-vs-recompute decision.
+"""
+
+from elastic_notebook.algorithm.optimizer_exact import OptimizerExact
+from elastic_notebook.core.graph.graph import DependencyGraph
+
+
+def _single_var_graph(size, cell_runtime):
+    """Graph: one cell with no inputs producing a single variable `x`."""
+    g = DependencyGraph()
+    vs = g.create_variable_snapshot("x", False)
+    g.add_cell_execution("x = f()", cell_runtime, 0.0, set(), {vs})
+    vs.size = size
+    return g, vs
+
+
+def _run(graph, active_vs, migration_speed_bps=1):
+    opt = OptimizerExact(migration_speed_bps=migration_speed_bps)
+    opt.dependency_graph = graph
+    opt.active_vss = {active_vs}
+    opt.overlapping_vss = set()
+    return opt.select_vss()
+
+
+def test_large_variable_cheap_recompute_is_recomputed():
+    # Huge migration cost, tiny recomputation cost -> recompute, do not migrate.
+    g, vs = _single_var_graph(size=1_000_000, cell_runtime=0.001)
+    vss_to_migrate, ces_to_recompute = _run(g, vs)
+    assert vss_to_migrate == set()
+    assert ces_to_recompute == {g.cell_executions[0]}
+
+
+def test_expensive_cell_small_variable_is_migrated():
+    # Tiny migration cost, huge recomputation cost -> migrate, do not recompute.
+    g, vs = _single_var_graph(size=1, cell_runtime=1_000_000)
+    vss_to_migrate, ces_to_recompute = _run(g, vs)
+    assert vss_to_migrate == {vs}
+    assert ces_to_recompute == set()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'darwin'",
@@ -1096,7 +1096,7 @@ wheels = [
 
 [[package]]
 name = "elastic-kernel"
-version = "0.0.27"
+version = "0.0.28"
 source = { editable = "." }
 dependencies = [
     { name = "dill" },
@@ -1135,6 +1135,9 @@ dev = [
     { name = "isort", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mypy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "mypy", version = "1.18.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "twine", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "twine", version = "6.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
@@ -1159,6 +1162,7 @@ dev = [
     { name = "flake8", specifier = ">=5.0.4" },
     { name = "isort", specifier = ">=5.13.2" },
     { name = "mypy", specifier = ">=1.14.1" },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "twine", specifier = ">=6.1.0" },
 ]
 
@@ -1368,6 +1372,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/be/f3e8c6081b684f176b761e6a2fef02a0be939740ed6f54109a2951d806f3/importlib_resources-6.4.5.tar.gz", hash = "sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065", size = 43372, upload-time = "2024-09-09T17:03:14.677Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/6a/4604f9ae2fa62ef47b9de2fa5ad599589d28c9fd1d335f32759813dfa91e/importlib_resources-6.4.5-py3-none-any.whl", hash = "sha256:ac29d5f956f01d5e4bb63102a5a19957f1b9175e45649977264a1416783bb717", size = 36115, upload-time = "2024-09-09T17:03:13.39Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.9.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -3409,6 +3447,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.9.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.9.*' and sys_platform == 'darwin'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3958,6 +4030,77 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.9' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.9'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "packaging", marker = "python_full_version < '3.9'" },
+    { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "tomli", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.9.*' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version == '3.9.*' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.9.*'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "packaging", marker = "python_full_version == '3.9.*'" },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pygments", marker = "python_full_version == '3.9.*'" },
+    { name = "tomli", marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

`docs/prompts/refactor-instructions.md` の **Phase 1（安全網の構築）** を実施。
チェックポイント保存・復元という壊れると致命的な機能にテストが1つも無い状態（D-1）を解消する。

**プロダクションコードは一切変更していない。** 追加したのはテスト・dev依存（pytest）・CI のみ。現行挙動をそのまま固定している。

## 追加したテスト（40件、全パス）

| ファイル | 対象 |
| --- | --- |
| `test_find_input_vars.py` | 単純参照 / AugAssign / 関数内ローカル / global宣言 / プリミティブ除外 / UDF再帰 |
| `test_find_output_vars.py` | 作成・削除・アンダースコア除外 |
| `test_id_graph.py` | construct / structure / root equals、ネスト・共有参照・循環参照・None |
| `test_object_hash.py` | プリミティブ / numpy ハッシュ、インプレース変更 vs 上書きの判別 |
| `test_graph.py` | バージョン採番、エッジ接続、update_graph、削除フラグ |
| `test_optimizer.py` | `OptimizerExact.select_vss` の「サイズ極大→再計算」「実行時間極大→マイグレート」2ケース |
| `test_checkpoint_file.py` | ビルダー set/get |
| `test_migrate_resume.py` | migrate→resume ラウンドトリップ + 異常系（破損ファイル） |
| `test_integration.py` | record_event→checkpoint→load_checkpoint（実IPythonシェル、Jupyter不要） |

## 重要ポイント

- **D-2 の現行バグを異常系テストで明示的に固定。** 破損した変数グループを読んでも例外を出さず、かつ「`ces_to_recompute` への再計算追加が破棄される」現行の誤挙動を `assert ces_to_recompute == set()` でピン留めし、「Phase 4 で反転する」とコメント済み。
- `__skip_record` のテストは指示書どおり Phase 4 に保留（カーネルのインスタンス化が重く private name-mangling のため）。

## 変更ファイル

- `tests/` 一式（新規）
- `pyproject.toml` — pytest を dev 依存に追加、`[tool.pytest.ini_options]` 設定
- `uv.lock` — pytest 追加に伴う更新
- `.github/workflows/test.yml` — pytest 実行ジョブを新規追加（既存ワークフローは不変）

## 検証結果

| コマンド | baseline | 本PR |
| --- | --- | --- |
| `uv run pytest` | 0（存在せず） | **40 passed** |
| `uv run black --check elastic_kernel elastic_notebook tests` | ✅ | ✅ |
| import スモーク（kernel / notebook） | ✅ | ✅ |
| `uv run mypy elastic_kernel elastic_notebook` | 29 | 29（不変） |

## 挙動差分

- **意図して変えた挙動**: なし（Phase 1 はテスト追加のみ）
- **テストで固定した既存挙動**: 上記すべて。D-2 は既知バグとして現行挙動のまま固定。

Stop-And-Ask 該当事項なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)