### PR TITLE
build: リファクタリング Phase 2 — 検証コマンド整備・パッケージング・ドキュメント (D-3/D-9/D-10)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 88
+# E203/E731: black 互換のため無視。
+# E501: 行長は black に委ねる。black が折り返さない長い文字列・コメント・ログ
+#       メッセージ（行長超過の大半がこれ）まで flake8 で報告すると、production
+#       コードの無関係な整形やログ文言の改変が必要になるため除外する。
+extend-ignore = E203,E731,E501
+exclude = build,.venv,dist,.git,__pycache__

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,32 +22,35 @@ jupyter kernelspec list
 
 ### アプリケーションの実行
 
-**Docker Composeを使用する場合:**
+**Dockerを使用する場合:**
 ```sh
-docker compose up
-# http://localhost:8888 でJupyterLabにアクセス
-# "Python 3 (Elastic)" カーネルを選択
+docker run -p 8888:8888 ghcr.io/mryutaro/elastickernel
+# http://127.0.0.1:8888 でJupyterLabにアクセス
+# "Python 3 (ElasticKernel)" カーネルを選択
 ```
 
 **ローカル開発の場合:**
 ```sh
 # JupyterLabを起動
 jupyter lab
-# "Python 3 (Elastic)" カーネルを選択
+# "Python 3 (ElasticKernel)" カーネルを選択
 ```
 
 ### コード品質
 
 ```sh
 # コードフォーマット
-uv run black .
-uv run isort .
+uv run black elastic_kernel elastic_notebook tests
+uv run isort elastic_kernel elastic_notebook tests
 
 # リント
-uv run flake8
+uv run flake8 elastic_kernel elastic_notebook tests
 
 # 型チェック
 uv run mypy
+
+# テスト
+uv run pytest
 ```
 
 ### バージョン管理・リリース（PyPI / GHCR への公開）

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.md
-include elastic_notebook_slim/LICENSE
+include elastic_notebook/LICENSE
 recursive-include elastic_kernel *.py *.json

--- a/elastic_notebook/core/io/migrate.py
+++ b/elastic_notebook/core/io/migrate.py
@@ -135,7 +135,7 @@ def migrate(
                         f"    WARNING: Very large list detected ({len(obj):,} elements). This may take a long time to serialize."
                     )
                     logger.warning(
-                        f"    Consider using NumPy arrays or other more efficient data structures for large datasets."
+                        "    Consider using NumPy arrays or other more efficient data structures for large datasets."
                     )
 
             # dill.dumpの実行時間を計測
@@ -166,7 +166,7 @@ def migrate(
                     f"    This operation may take several minutes. Total elements: {total_size:,}"
                 )
                 logger.warning(
-                    f"    If the kernel becomes unresponsive, Jupyter may terminate it."
+                    "    If the kernel becomes unresponsive, Jupyter may terminate it."
                 )
 
             dill.dump(obj_list, output_file)

--- a/elastic_notebook/elastic_notebook.py
+++ b/elastic_notebook/elastic_notebook.py
@@ -53,9 +53,9 @@ class ElasticNotebook:
         self.log_file_path = os.path.join(log_file_dir, "ElasticNotebook.log")
         self.logger: logging.Logger
         self.__setup_logger()
-        self.logger.info(f"===============================================")
+        self.logger.info("===============================================")
         self.logger.info("ElasticNotebookを初期化しました")
-        self.logger.info(f"===============================================")
+        self.logger.info("===============================================")
 
         self.shell = shell
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,17 @@ elastic-kernel = "elastic_kernel.command:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
+include = ["elastic_kernel*", "elastic_notebook*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.isort]
+profile = "black"
+
+[tool.mypy]
+files = ["elastic_kernel", "elastic_notebook"]
+ignore_missing_imports = true
 
 [tool.setuptools.package-data]
 "elastic_kernel" = ["kernel.json", "kernel.py"]


### PR DESCRIPTION
## 概要

`docs/prompts/refactor-instructions.md` の **Phase 2（設定とドキュメントの整備）**。コードロジックは非接触（例外: 指示書が許可する F541 の f接頭辞除去のみ）。

> ⚠️ このPRは **Phase 1 (#35) にスタック**している。base は `refactor/phase1-tests`。#35 が main にマージされた後、本PRの base を main に切り替える想定。

## 変更内容

### D-3: 検証コマンドの整備
- `pyproject.toml`: `[tool.isort] profile="black"`、`[tool.mypy] files=[...] + ignore_missing_imports`
- `.flake8`: `max-line-length=88`、`extend-ignore=E203,E731,E501`
- F541（プレースホルダなし f-string）4件を f接頭辞除去で修正（無害）

### D-9: パッケージング
- `[tool.setuptools.packages.find]` に `include = ["elastic_kernel*","elastic_notebook*"]`
- `MANIFEST.in`: 存在しない `elastic_notebook_slim/LICENSE` → `elastic_notebook/LICENSE`
- git管理外の `build/`・`elastic_kernel.egg-info/` を削除

### D-10: ドキュメント
- `CLAUDE.md`: `docker compose`→`docker run`、表示名 `Python 3 (Elastic)`→`Python 3 (ElasticKernel)`、lint/mypy/pytest コマンドを実態に修正

## 検証結果（baseline → 本PR）

| 項目 | baseline | 本PR |
| --- | --- | --- |
| flake8 | 163 | **0** |
| isort --check-only | 5件失敗 | **0** |
| mypy | 29 | **20**（baseline 以下）|
| black --check | clean | clean |
| pytest | 40 | **40 passed** |
| `uv build` | — | wheel=2パッケージのみ / sdist に LICENSE / build/ 混入なし |

## 指示書からの逸脱（要レビュー）

D-3 は「E501 は config で解消するはず」を想定していたが、実際は black が折り返さない長い文字列・コメント・ログ f-string が **72件残存**。production 72行の整形・ログ文言改変は非交渉事項に抵触するため、**`.flake8` で E501 を ignore**（black に行長管理を委ねる標準手法、設定のみ）に方針変更した。`.flake8` に理由をコメント済み。

## 挙動差分

- ロジック変更なし。F541 の f接頭辞除去は出力文字列を変えない（プレースホルダがないため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)