### PR TITLE
fix: リファクタリング Phase 3 — 安全なコード修正（挙動同一）(D-6/D-8/D-11)

### DIFF
--- a/elastic_kernel/kernel.py
+++ b/elastic_kernel/kernel.py
@@ -1,10 +1,13 @@
 import hashlib
 import json
 import logging
+import logging.handlers
 import os
 import time
 import traceback
 import urllib
+import urllib.parse
+import urllib.request
 from datetime import datetime, timedelta, timezone
 
 from ipykernel.ipkernel import IPythonKernel
@@ -294,16 +297,18 @@ class ElasticKernel(IPythonKernel):
 
         self.logger.debug(f"Executing Code:\n{code}")
 
+        skip_record = self.__skip_record(code)
+
         pre_execution_user_ns = (
-            set(self.shell.user_ns.keys()) if not self.__skip_record(code) else None
+            set(self.shell.user_ns.keys()) if not skip_record else None
         )
-        start_time = time.time() if not self.__skip_record(code) else None
+        start_time = time.time() if not skip_record else None
 
         result = await super().do_execute(
             code, silent, store_history, user_expressions, allow_stdin
         )
 
-        if not self.__skip_record(code):
+        if not skip_record:
             cell_runtime = time.time() - start_time
             self.logger.debug(f"Cell runtime: {cell_runtime}")
             self.elastic_notebook.record_event(

--- a/elastic_notebook/core/common/profile_migration_speed.py
+++ b/elastic_notebook/core/common/profile_migration_speed.py
@@ -3,6 +3,7 @@
 
 import os
 import pickle
+import shutil
 import sys
 import time
 
@@ -19,7 +20,8 @@ def profile_migration_speed(dirname: str, alpha=1) -> float:
     filecount = 1
     max_time = 0.8
     testing_dir = os.path.join(dirname, "measure_speed")
-    os.system("rm -rf {} && mkdir {}".format(testing_dir, testing_dir))
+    shutil.rmtree(testing_dir, ignore_errors=True)
+    os.makedirs(testing_dir)
     total_bytes = 0
 
     start_time = time.time()
@@ -58,7 +60,7 @@ def profile_migration_speed(dirname: str, alpha=1) -> float:
         if time.time() - start_time > max_time:
             break
 
-    os.system("rm -rf {}".format(testing_dir))
+    shutil.rmtree(testing_dir, ignore_errors=True)
 
     migration_speed_bps = total_bytes / (total_read_time + total_write_time * alpha)
 

--- a/tests/test_profile_migration_speed.py
+++ b/tests/test_profile_migration_speed.py
@@ -1,0 +1,31 @@
+"""Tests for profile_migration_speed.
+
+D-11 (first half): the function previously shelled out via
+os.system("rm -rf {} && mkdir {}"), which breaks (or worse) when the notebook
+directory path contains spaces or shell metacharacters. It now uses
+shutil.rmtree + os.makedirs, so a path with a space must work cleanly.
+"""
+
+from pathlib import Path
+
+from elastic_notebook.core.common.profile_migration_speed import (
+    profile_migration_speed,
+)
+
+
+def test_handles_directory_with_space(tmp_path):
+    spaced_dir = tmp_path / "dir with space"
+    spaced_dir.mkdir()
+
+    result = profile_migration_speed(str(spaced_dir))
+
+    # Returns a numeric speed and does not raise on the spaced path.
+    assert isinstance(result, float)
+    # The scratch directory is cleaned up afterwards.
+    assert not (spaced_dir / "measure_speed").exists()
+
+
+def test_creates_and_cleans_scratch_dir(tmp_path):
+    result = profile_migration_speed(str(tmp_path))
+    assert isinstance(result, float)
+    assert not (Path(tmp_path) / "measure_speed").exists()


### PR DESCRIPTION
## 概要

`docs/prompts/refactor-instructions.md` の **Phase 3（明らかに安全なコード修正・挙動同一）**。

> ⚠️ **Phase 2 (#37) にスタック**。base は `refactor/phase2-config`。
> マージ順: #35 → #37 → 本PR。上流がmainに入るたびに base を繰り上げる想定。

## 変更内容

### D-6: 暗黙のサブモジュール import を明示化（`elastic_kernel/kernel.py`）
`import logging` だけで `logging.handlers.RotatingFileHandler` を、`import urllib` だけで `urllib.request`/`urllib.parse` を使っていた。ipykernel が先に import していたため偶然動いていたが、依存先の変更で `AttributeError` になり得た。
→ `import logging.handlers` / `import urllib.parse` / `import urllib.request` を明示追加（挙動同一）。

### D-8（前半）: `do_execute` の冗長性解消（`elastic_kernel/kernel.py`）
`self.__skip_record(code)` を3回呼んでいたのを `skip_record` に1回だけ評価して再利用（挙動同一）。
※ 後半（Q3＝成功セルのみ記録）は挙動が変わるため Phase 4。

### D-11（前半）: 危険なシェル実行の置換（`elastic_notebook/core/common/profile_migration_speed.py`）
`os.system("rm -rf {} && mkdir {}")` をパスのスペース/特殊文字に対して安全な `shutil.rmtree(ignore_errors=True)` + `os.makedirs` に置換（挙動同一）。**スペースを含むパスのテストを追加。**
※ 後半（read 計測が1バイトも読んでいない問題）は migration_speed 値を変えるため Phase 6 提案のみ。

## 検証結果

| 項目 | 値 |
| --- | --- |
| pytest | **42 passed**（40 + 新規2）|
| import スモーク | ✅ kernel / notebook |
| black --check | clean（47ファイル）|
| isort --check-only | 0 |
| flake8 | 0 |
| mypy | 20（変化なし）|

## 挙動差分

- すべて挙動同一の修正。意図して変えた挙動はなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)