### PR TITLE
ci: auto-formatのdetached HEAD pushを修正 (#36)

### DIFF
--- a/.github/workflows/format-python-code.yml
+++ b/.github/workflows/format-python-code.yml
@@ -20,6 +20,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # pull_request ではマージ commit が detached HEAD でチェックアウトされ
+          # git push が失敗する。PR の元ブランチを明示してブランチ状態にする。
+          # push（main）イベント時は github.head_ref が空なので既定の挙動になる。
+          ref: ${{ github.head_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## 概要

`.github/workflows/format-python-code.yml`（auto-format）が `pull_request` イベントで必ず失敗する問題（#36）を修正する。

## 原因

`pull_request` イベントでは `actions/checkout` がマージ commit を **detached HEAD** でチェックアウトするため、ワークフロー末尾の `git push`（暗黙に現在ブランチを push）が以下で失敗していた:

```
fatal: You are not currently on a branch.
##[error]Process completed with exit code 128.
```

ファイル内容やフォーマット差分とは無関係な構造的問題で、どの PR でも再現する（main への `push` イベント時のみ成功）。

## 修正内容

Issue の修正案 **2** を採用。`actions/checkout` に `ref: ${{ github.head_ref }}` を指定し、PR の元ブランチをブランチ状態でチェックアウトしてから push する。

- `pull_request` 時: `github.head_ref` = PR の元ブランチ → ブランチ状態で checkout → `git push` 成功
- `push`（main）時: `github.head_ref` は空 → 既定の挙動になり影響なし

自動整形運用を維持する方針（Q2）に沿った変更。

## 関連

- Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)