### PR TITLE
chore: リファクタリング Phase 5 — 型整理で mypy をゼロエラー化 (Phase 5)

### DIFF
--- a/elastic_notebook/algorithm/optimizer_exact.py
+++ b/elastic_notebook/algorithm/optimizer_exact.py
@@ -1,6 +1,8 @@
 # This file has been modified from the original ElasticNotebook.
 # Original: https://github.com/illinoisdata/ElasticNotebook
 
+from typing import Union
+
 import networkx as nx
 import numpy as np
 from networkx.algorithms.flow import shortest_augmenting_path
@@ -23,9 +25,6 @@ class OptimizerExact(Selector):
         self.active_oes = None
         self.compute_graph = None
 
-        # CEs required to recompute a variables last modified by a given CE.
-        self.recomputation_ces = {}
-
         self.idx = 0
 
     def get_new_idx(self) -> int:
@@ -36,7 +35,12 @@ class OptimizerExact(Selector):
         self.idx += 1
         return idx
 
-    def dfs(self, current: str, visited: set, recompute_ces: str):
+    def dfs(
+        self,
+        current: Union[CellExecution, VariableSnapshot, None],
+        visited: set,
+        recompute_ces: set,
+    ):
         """
         Perform DFS on the Application History Graph for finding the CEs required to recompute a variable.
         Args:
@@ -71,7 +75,7 @@ class OptimizerExact(Selector):
                 self.dfs(ce, set(), recompute_ces)
                 self.recomputation_ces[ce] = recompute_ces
 
-    def select_vss(self, notebook_name=None, optimizer_name=None) -> set:
+    def select_vss(self, notebook_name=None, optimizer_name=None) -> tuple:
         self.find_prerequisites()
 
         # Construct flow graph for computing mincut

--- a/elastic_notebook/algorithm/selector.py
+++ b/elastic_notebook/algorithm/selector.py
@@ -18,7 +18,11 @@ class Selector:
         self.overlapping_vss = None
         self.migration_speed_bps = migration_speed_bps
 
-    def select_vss(self, notebook_name=None, optimizer_name=None) -> set:
+        # CEs required to recompute a variable last modified by a given CE.
+        # Declared on the base so callers (e.g. checkpoint()) can rely on it.
+        self.recomputation_ces: dict = {}
+
+    def select_vss(self, notebook_name=None, optimizer_name=None) -> tuple:
         """
         Classes that inherit from the `Selector` class (such as `OptimizerExact`) should
         override `select_vss`.

--- a/elastic_notebook/core/common/profile_migration_speed.py
+++ b/elastic_notebook/core/common/profile_migration_speed.py
@@ -26,8 +26,8 @@ def profile_migration_speed(dirname: str, alpha=1) -> float:
 
     start_time = time.time()
 
-    total_read_time = 0
-    total_write_time = 0
+    total_read_time = 0.0
+    total_write_time = 0.0
     for i in range(filecount):
         # write_array_large = np.random.rand(10000, 10000)
         write_array_large = np.random.rand(500, 500)

--- a/elastic_notebook/core/graph/cell_execution.py
+++ b/elastic_notebook/core/graph/cell_execution.py
@@ -5,9 +5,6 @@
 #
 # This file has been modified from the original ElasticNotebook.
 # Original: https://github.com/illinoisdata/ElasticNotebook
-from typing import List
-
-
 class CellExecution:
     """
     A cell execution (object) corresponds to a cell execution (action, i.e. press play) in the notebook session.
@@ -19,8 +16,8 @@ class CellExecution:
         cell: str,
         cell_runtime: float,
         start_time: float,
-        src_vss: List,
-        dst_vss: List,
+        src_vss: set,
+        dst_vss: set,
     ):
         """
         Create an operation event from cell execution metrics.

--- a/elastic_notebook/core/graph/graph.py
+++ b/elastic_notebook/core/graph/graph.py
@@ -2,7 +2,6 @@
 # Original: https://github.com/illinoisdata/ElasticNotebook
 
 from collections import defaultdict
-from typing import List
 
 from elastic_notebook.core.graph.cell_execution import CellExecution
 from elastic_notebook.core.graph.variable_snapshot import VariableSnapshot
@@ -48,7 +47,7 @@ class DependencyGraph:
         return vs
 
     def add_cell_execution(
-        self, cell, cell_runtime: float, start_time: float, src_vss: List, dst_vss: List
+        self, cell, cell_runtime: float, start_time: float, src_vss: set, dst_vss: set
     ):
         """
         Create a cell execution from captured metrics.

--- a/elastic_notebook/core/graph/variable_snapshot.py
+++ b/elastic_notebook/core/graph/variable_snapshot.py
@@ -26,7 +26,7 @@ class VariableSnapshot:
         self.deleted = deleted
 
         # Cell executions accessing this variable snapshot (i.e. require this variable snapshot to run).
-        self.input_ces = []
+        self.input_ces: list = []
 
         # The unique cell execution creating this variable snapshot.
         self.output_ce = None

--- a/elastic_notebook/core/io/migrate.py
+++ b/elastic_notebook/core/io/migrate.py
@@ -53,7 +53,7 @@ def migrate(
     logger.debug(f"{udfs=}")
 
     # construct serialization order list.
-    temp_dict = {}
+    temp_dict: dict = {}
     serialization_order = []
     for vs1, vs2 in overlapping_vss:
         if vs1 in temp_dict:

--- a/elastic_notebook/core/notebook/find_input_vars.py
+++ b/elastic_notebook/core/notebook/find_input_vars.py
@@ -92,7 +92,7 @@ def find_input_vars(
     function_defs = v1.functiondefs
 
     # Recurse into accessed UDFs.
-    udf_calls = deque()
+    udf_calls: deque = deque()
     udf_calls_visited = set()
 
     for udf in v1.udfcalls:

--- a/elastic_notebook/elastic_notebook.py
+++ b/elastic_notebook/elastic_notebook.py
@@ -49,10 +49,10 @@ class ElasticNotebook:
         self.selector = OptimizerExact(migration_speed_bps=self.migration_speed_bps)
 
         # Dictionary of object fingerprints. For detecting modified references.
-        self.fingerprint_dict = {}
+        self.fingerprint_dict: dict = {}
 
         # Set of user-declared functions.
-        self.udfs = set()
+        self.udfs: set = set()
 
         # Flag if migration speed has been manually set. In this case, skip profiling of migration speed at checkpoint
         # time.
@@ -70,8 +70,8 @@ class ElasticNotebook:
         self.profile_dict = {"idgraph": 0, "representation": 0}
 
         # マイグレーションと再計算の変数リスト
-        self._vss_to_migrate = []
-        self._vss_to_recompute = []
+        self._vss_to_migrate: list = []
+        self._vss_to_recompute: list = []
 
     @property
     def vss_to_migrate(self):


### PR DESCRIPTION
## 概要

`docs/prompts/refactor-instructions.md` の **Phase 5（残りの低リスク改善）**。**ロジック非接触の型アノテーション修正のみ**で mypy を **29件 → 0件** にする。

> ⚠️ **Phase 4 (#40) にスタック**。base は `refactor/phase4-fixes`。マージ順: #35 → #37 → #38 → #40 → 本PR。

## 変更内容（すべて型/アノテーションのみ・挙動不変）

- **var-annotated**: `fingerprint_dict` / `udfs` / `_vss_to_migrate` / `_vss_to_recompute`（`elastic_notebook.py`）、`input_ces`（`variable_snapshot.py`）、`udf_calls`（`find_input_vars.py`）、`temp_dict`（`migrate.py`）
- **int→float**: `profile_migration_speed` の `total_read_time` / `total_write_time` 初期値を `0` → `0.0`
- **誤アノテーション修正**: `graph.add_cell_execution` / `CellExecution` の `src_vss`/`dst_vss` を `List` → `set`（実体に一致）、`optimizer_exact.dfs(current: Union[CellExecution, VariableSnapshot, None])`、`select_vss(...) -> tuple`
- **`Selector` 基底に `recomputation_ces` を宣言**: `checkpoint()` の `selector.recomputation_ces` 参照を型安全に（OptimizerExact 側の重複定義は削除）。D-5 の仕上げ。

## D-12 について（提案保留）

`checkpoint.py` の `fingerprint_dict[name]` 参照の KeyError ガードは、「fingerprint の無い active VS が発生し得るか」という不変条件をテストで証明できていないため、指示書の条件に従い **Phase 6 提案に留める**（本PRでは追加しない）。

## 検証結果

| 項目 | baseline | 本PR |
| --- | --- | --- |
| mypy | 29 | **0**（Success: no issues found）|
| flake8 | 163 | 0 |
| isort | 5件失敗 | 0 |
| black --check | clean | clean |
| pytest | 0 | **51 passed** |
| import スモーク | ✅ | ✅ |

## 挙動差分

- なし（型アノテーション・初期値の int→float・誤アノテーション修正のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)