### PR TITLE
fix: 復元後マジックコマンドのみ実行→shutdown時のKeyErrorを修正 (#26)

### DIFF
--- a/elastic_notebook/core/notebook/checkpoint.py
+++ b/elastic_notebook/core/notebook/checkpoint.py
@@ -56,6 +56,14 @@ def checkpoint(
     profiled_count = 0
     for i, active_vs in enumerate(active_vss):
         logger.debug(f"Profiling variable {i+1}/{len(active_vss)}: {active_vs.name}")
+        # グラフ上はアクティブでも user_ns に存在しない変数はプロファイル/マイグレート
+        # できないため、サイズを無限大（マイグレーション対象外）として扱い KeyError を避ける。
+        if active_vs.name not in shell.user_ns:
+            active_vs.size = np.inf
+            logger.debug(
+                f"  Variable '{active_vs.name}' not in user_ns; skipping profiling"
+            )
+            continue
         attr_str = getattr(shell.user_ns[active_vs.name], "__module__", None)
         # Object is unserializable
         if active_vs.name in fingerprint_dict and isinstance(
@@ -82,9 +90,16 @@ def checkpoint(
     overlapping_vss = []
     for active_vs1 in active_vss:
         for active_vs2 in active_vss:
-            if active_vs1 != active_vs2 and fingerprint_dict[active_vs1.name][
-                1
-            ].intersection(fingerprint_dict[active_vs2.name][1]):
+            # fingerprint_dict に未登録の変数（例: 復元直後にマジックのみ実行した場合）が
+            # あっても KeyError にならないよう存在チェックを行う（issue #26）。
+            if (
+                active_vs1 != active_vs2
+                and active_vs1.name in fingerprint_dict
+                and active_vs2.name in fingerprint_dict
+                and fingerprint_dict[active_vs1.name][1].intersection(
+                    fingerprint_dict[active_vs2.name][1]
+                )
+            ):
                 overlapping_vss.append((active_vs1, active_vs2))
 
     profile_end = time.time()

--- a/elastic_notebook/elastic_notebook.py
+++ b/elastic_notebook/elastic_notebook.py
@@ -356,6 +356,18 @@ class ElasticNotebook:
             ces_to_recompute,
         )
 
+        # 復元した変数のフィンガープリントを再構築する。
+        # 復元直後は fingerprint_dict が空であり、マジックコマンド（%whos 等）は
+        # record_event をスキップするため、それのみを実行してから checkpoint() すると
+        # fingerprint_dict に変数が存在せず KeyError になる（issue #26）。
+        # ここで復元済み変数のフィンガープリントを先に構築しておくことで防ぐ。
+        self.fingerprint_dict = {}
+        for var in self.dependency_graph.variable_snapshots.keys():
+            if var in self.shell.user_ns:
+                self.fingerprint_dict[var] = construct_fingerprint(
+                    self.shell.user_ns[var], self.profile_dict
+                )
+
         # 読み込んだメタデータから、マイグレートされた変数と再計算される変数を取得
         adapter = FilesystemAdapter()
         metadata = adapter.read_all(Path(filename))


### PR DESCRIPTION
## 概要
Issue #26 のチェックポイント保存時 `KeyError` を修正します。

## 症状
1. カーネル再起動でチェックポイントから復元
2. 通常のセルを実行せず `%whos` などマジックコマンドのみ実行
3. カーネル shutdown

このとき保存処理で `KeyError`（例: `KeyError: 'datetime'`）が発生していた。**アクティブ変数が2個以上**のとき再現する（1個だと `checkpoint.py` の二重ループで `active_vs1 != active_vs2` が常に偽になり、該当アクセスが評価されないため出ない）。

## 原因
復元直後は `fingerprint_dict`（変数の指紋）が空。マジックコマンドは `record_event` をスキップするため空のまま埋まらず、その状態で `checkpoint()` が `fingerprint_dict[変数名]` に**存在チェックなしでアクセス**して落ちる。

## 修正
- **`elastic_notebook.py` `load_checkpoint`（根本対応 / 解決方法2）**: 復元した変数の fingerprint を再構築しておき、以降の `checkpoint()` / `record_event()` が空 dict を踏まないようにする。
- **`checkpoint.py` overlapping 判定（防御 / 解決方法1）**: `fingerprint_dict` の存在チェックを追加し `KeyError` を回避。
- **`checkpoint.py` サイズ計測ループ（防御）**: `user_ns` に存在しないアクティブ変数はサイズ∞（マイグレート対象外）扱いでスキップ。

## 検証
- 修正前: 2変数シナリオ（`datetime` + 他）で `Error saving checkpoint: 'datetime'` を Docker（公開イメージ相当）で再現。
- 修正後: 同シナリオで KeyError が消えることを確認。

## 補足（別件）
別途報告のある「再起動後 Run All がセル1で止まる／2回目で通る」現象は、本修正の対象外です。あちらは **JupyterLab の再起動時 iopub(PUB/SUB) 再接続レース**で、素の `ipykernel` でも発生するため本 PR では扱いません。

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)