### PR TITLE
docs: use user-attachments URLs for inline demo video playback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,12 @@ uv run pytest
 - dillをシリアライゼーションに使用（Pythonオブジェクトに対してpickleより強力）
 - マイグレーション速度のプロファイリングは `alpha` パラメータを使用してコストスケーリングを調整
 
+## README編集時の注意
+
+- `README.md`（英語）と `README.ja.md`（日本語）は内容を**常に同期**させる。片方を修正したら必ずもう片方にも同じ修正を反映する。
+- デモ動画の名前は `ipykernel` と `elastickernel` のみを使う。`-edited` などのサフィックスは付けない。
+- README内でのデモ動画のインライン再生には、リポジトリ内ファイルの `raw` URL ではなく、GitHubにドラッグ&ドロップでアップロードして得られる `https://github.com/user-attachments/assets/...` のURLを `<video src>` に指定する（raw URL は Content-Type と CSP の制約でインライン再生されない）。
+
 ## 開発時のテスト
 
 カーネルの変更をテストするには：

--- a/README.ja.md
+++ b/README.ja.md
@@ -21,8 +21,8 @@ ElasticKernel は、ノートブックの実行状態を**自動でチェック�
 <th align="center">ElasticKernel</th>
 </tr>
 <tr>
-<td width="50%"><video src="https://github.com/MRyutaro/ElasticKernel/raw/main/docs/assets/ipykernel.mp4" controls muted></video></td>
-<td width="50%"><video src="https://github.com/MRyutaro/ElasticKernel/raw/main/docs/assets/elastickernel.mp4" controls muted></video></td>
+<td width="50%"><video src="https://github.com/user-attachments/assets/9ba4d267-20e8-4b06-a3ea-869c19687f81" controls muted></video></td>
+<td width="50%"><video src="https://github.com/user-attachments/assets/9f3c7acc-2ae9-4f98-873c-60f37f1a434e" controls muted></video></td>
 </tr>
 <tr>
 <td align="center">❌ 再起動後、<code>a</code> は<b>消えています</b>。<code>%whos</code> は <i>「Interactive namespace is empty.」</i> と表示します。</td>

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The same workflow in both clips: define a variable `a = 1`, then **restart the k
 <th align="center">ElasticKernel</th>
 </tr>
 <tr>
-<td width="50%"><video src="https://github.com/MRyutaro/ElasticKernel/raw/main/docs/assets/ipykernel.mp4" controls muted></video></td>
-<td width="50%"><video src="https://github.com/MRyutaro/ElasticKernel/raw/main/docs/assets/elastickernel.mp4" controls muted></video></td>
+<td width="50%"><video src="https://github.com/user-attachments/assets/9ba4d267-20e8-4b06-a3ea-869c19687f81" controls muted></video></td>
+<td width="50%"><video src="https://github.com/user-attachments/assets/9f3c7acc-2ae9-4f98-873c-60f37f1a434e" controls muted></video></td>
 </tr>
 <tr>
 <td align="center">❌ After the restart, <code>a</code> is <b>gone</b> — <code>%whos</code> reports <i>"Interactive namespace is empty."</i></td>


### PR DESCRIPTION
## 概要

README のデモ動画がインライン再生されない問題を修正。

`<video src>` にリポジトリ内ファイルの `raw` URL を指定していたが、これは GitHub 上で Content-Type（`application/octet-stream`）と CSP の制約によりインライン再生されない。ドラッグ&ドロップでアップロードした `user-attachments` URL に差し替えた。

## 変更内容

- `README.md` / `README.ja.md`: `<video src>` を user-attachments URL に差し替え（英語版・日本語版を同期）
- `CLAUDE.md`: 「README編集時の注意」を追加
  - 英語版・日本語版を常に同期させる
  - デモ動画名は `ipykernel` / `elastickernel` のみ（`-edited` などのサフィックス禁止）
  - インライン再生には raw URL ではなく user-attachments URL を使う

`docs:` コミットのためリリースのバージョンは上がらない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)