### PR TITLE
docs: fix misleading min-cut comment in optimizer_exact

### DIFF
--- a/elastic_notebook/algorithm/optimizer_exact.py
+++ b/elastic_notebook/algorithm/optimizer_exact.py
@@ -112,7 +112,7 @@ class OptimizerExact(Selector):
             if mincut_graph.in_degree(ce) == 0:
                 mincut_graph.remove_node(ce)
 
-        # Solve min-cut with Ford-Fulkerson.
+        # Solve min-cut with the shortest augmenting path algorithm.
         cut_value, partition = nx.minimum_cut(
             mincut_graph, "source", "sink", flow_func=shortest_augmenting_path
         )


### PR DESCRIPTION
## 概要

`optimizer_exact.py` の min-cut 計算箇所のコメントが実装と食い違っていたため修正します。

- コメント: `Solve min-cut with Ford-Fulkerson.`
- 実装: `flow_func=shortest_augmenting_path`（L8 で import）

実際には Ford-Fulkerson ではなく `shortest_augmenting_path` を使っているため、コメントを実装に合わせました。

## 背景（#22 の調査結果）

#22「min-cut アルゴリズムを Edmonds-Karp → Ford-Fulkerson に変えるとどうなるか」の調査で、以下が判明しました。

- **最適コスト（cut_value）には影響しない**: 最大フロー最小カット定理により、正しいアルゴリズムなら最小カット値（=チェックポイント総コスト）は必ず一致する。
- **分割（migrate/recompute の選択）**: 最小カットが同点で複数存在する場合に変わりうるが、総コストは同じ（コスト中立）。
- **純粋な Ford-Fulkerson は非推奨**: float 容量＋`np.inf` エッジでは終了保証がなく遅化リスクがあり、そもそも networkx に `ford_fulkerson` は存在しない（削除済み）。

よって実装の変更はせず、この PR では誤ったコメントの修正のみを行います。

Close #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)