### PR TITLE
fix: stabilize migration speed measurement to prevent runaway checkpoints

### DIFF
--- a/elastic_notebook/core/common/profile_migration_speed.py
+++ b/elastic_notebook/core/common/profile_migration_speed.py
@@ -4,66 +4,65 @@
 import os
 import pickle
 import shutil
-import sys
 import time
 
 import numpy as np
 
+# Realistic bounds for the combined read+write speed (bytes/s). Values outside
+# this band almost always indicate a measurement artifact rather than the real
+# disk/serialization throughput, so they are treated as invalid. See issue #21.
+MIN_SPEED_BPS = 1e6  # 1 MB/s  - implausibly slow
+MAX_SPEED_BPS = 2e9  # 2 GB/s  - implausibly fast for a write+read round trip
+FALLBACK_SPEED_BPS = 5e8  # 500 MB/s - sane default when measurement is invalid
+
 
 def profile_migration_speed(dirname: str, alpha=1) -> float:
     """
-    The migration speed is the sum of read and write speed (since we are writing the state to disk, then
-    reading from disk to restore the notebook). The function should ideally be fast (<1 sec).
+    The migration speed is the combined read+write throughput (we write the state to disk,
+    then read it back to restore the notebook). The measurement should be fast (<1 sec).
+
+    Unlike the original implementation, this does NOT use a large-minus-small differencing
+    trick: with small test arrays the timing difference is dominated by noise and can become
+    near-zero or negative, producing absurd speeds (e.g. 7 GB/s) that make the optimizer
+    migrate huge variables and stall the checkpoint (issue #21). Instead we measure a single
+    fixed-size array directly and clamp the result to a realistic range.
+
     Args:
         dirname: Location to profile.
+        alpha: Scaling factor applied to the write time relative to the read time.
     """
-    filecount = 1
-    max_time = 0.8
     testing_dir = os.path.join(dirname, "measure_speed")
     shutil.rmtree(testing_dir, ignore_errors=True)
     os.makedirs(testing_dir)
-    total_bytes = 0
 
-    start_time = time.time()
-
-    total_read_time = 0.0
-    total_write_time = 0.0
-    for i in range(filecount):
-        # write_array_large = np.random.rand(10000, 10000)
-        write_array_large = np.random.rand(500, 500)
-        write_array_small = np.random.rand(100, 100)
-        total_bytes += sys.getsizeof(write_array_large)
-        total_bytes -= sys.getsizeof(write_array_small)
+    try:
+        # ~8 MB: large enough that write+read is well above timer resolution
+        # (giving a stable measurement) yet small enough to finish in tens of ms.
+        write_array = np.random.rand(1000, 1000)
+        total_bytes = write_array.nbytes
+        path = os.path.join(testing_dir, "probe")
 
         write_start = time.time()
-        out_file = open(os.path.join(testing_dir, str(i) + "large"), "wb")
-        pickle.dump(write_array_large, out_file)
-        out_file.close()
-        total_write_time += time.time() - write_start
+        with open(path, "wb") as out_file:
+            pickle.dump(write_array, out_file)
+        write_time = time.time() - write_start
 
         read_start = time.time()
-        in_file = open(os.path.join(testing_dir, str(i)) + "large", "rb")
-        in_file.read()  # D-11: actually read the bytes so read speed is measured
-        in_file.close()
-        total_read_time += time.time() - read_start
+        with open(path, "rb") as in_file:
+            in_file.read()  # actually read the bytes so read speed is measured
+        read_time = time.time() - read_start
+    finally:
+        shutil.rmtree(testing_dir, ignore_errors=True)
 
-        write_start = time.time()
-        out_file = open(os.path.join(testing_dir, str(i) + "small"), "wb")
-        pickle.dump(write_array_small, out_file)
-        out_file.close()
-        total_write_time -= time.time() - write_start
+    denominator = read_time + write_time * alpha
 
-        read_start = time.time()
-        in_file = open(os.path.join(testing_dir, str(i) + "small"), "rb")
-        in_file.read()  # D-11: actually read the bytes so read speed is measured
-        in_file.close()
-        total_read_time -= time.time() - read_start
+    # Guard against a zero/negative denominator (timer resolution) and against
+    # non-finite or out-of-range results; fall back to a sane default.
+    if denominator <= 0:
+        return FALLBACK_SPEED_BPS
 
-        if time.time() - start_time > max_time:
-            break
+    migration_speed_bps = total_bytes / denominator
+    if not np.isfinite(migration_speed_bps):
+        return FALLBACK_SPEED_BPS
 
-    shutil.rmtree(testing_dir, ignore_errors=True)
-
-    migration_speed_bps = total_bytes / (total_read_time + total_write_time * alpha)
-
-    return migration_speed_bps
+    return float(np.clip(migration_speed_bps, MIN_SPEED_BPS, MAX_SPEED_BPS))

--- a/elastic_notebook/elastic_notebook.py
+++ b/elastic_notebook/elastic_notebook.py
@@ -8,6 +8,7 @@ import os
 import time
 import types
 from os.path import dirname
+from typing import Optional
 
 from IPython.core.interactiveshell import InteractiveShell
 
@@ -47,6 +48,11 @@ class ElasticNotebook:
         self.migration_speed_bps = 100000
         self.alpha = 1
         self.selector = OptimizerExact(migration_speed_bps=self.migration_speed_bps)
+
+        # Cached profiled migration speed. Disk throughput is effectively constant within a
+        # session, so we profile only once and reuse the result on subsequent checkpoints to
+        # avoid adding measurement overhead to every checkpoint (issue #21).
+        self.profiled_migration_speed_bps: Optional[float] = None
 
         # Dictionary of object fingerprints. For detecting modified references.
         self.fingerprint_dict: dict = {}
@@ -241,11 +247,13 @@ class ElasticNotebook:
     def checkpoint(self, filename):
         self.logger.info("チェックポイントの保存を開始します")
 
-        # Profile the migration speed to filename.
+        # Profile the migration speed to filename (only once per session; see __init__).
         if not self.manual_migration_speed:
-            self.migration_speed_bps = profile_migration_speed(
-                dirname(filename), alpha=self.alpha
-            )
+            if self.profiled_migration_speed_bps is None:
+                self.profiled_migration_speed_bps = profile_migration_speed(
+                    dirname(filename), alpha=self.alpha
+                )
+            self.migration_speed_bps = self.profiled_migration_speed_bps
             self.selector.migration_speed_bps = self.migration_speed_bps
         self.logger.info(f"Migration speed: {self.migration_speed_bps} bytes/s")
 


### PR DESCRIPTION
## 概要

Migration speed の計測が不安定で異常値（例: `7164647402 bytes/s` ≒ 7 GB/s）を出すことがあり、オプティマイザが巨大変数まで「保存が安い」と誤判断してチェックポイントが終わらなくなる問題（#21）を修正します。

## 原因

`profile_migration_speed` が「大きい配列 − 小さい配列」の**差分**で速度を測っていたため、配列が小さい（`500x500` / `100x100`）と差分が μs オーダーのノイズに埋もれ、分母 `total_read_time + total_write_time` が**ほぼ0や負**になって速度が爆発していた。

> なお read 時間の過小評価（`read()` を実際に呼んでいなかった件）は既に main の `c0fdef6` で対応済み。本 PR は残っていたスパイクの主因（差分方式）を潰すもの。詳細は #21 のコメント参照。

## 変更

- **`fix:` 計測の安定化** — 差分方式を廃止し、~8 MB 配列1本の write+read を直接計測。非現実的な値は現実的レンジにクランプ、分母≤0/非有限はフォールバック値を返す。
- **`perf:` セッション内1回だけ計測** — ディスク速度はセッション中ほぼ一定なので、毎チェックポイントの再計測をやめて初回のみ測定・キャッシュ。checkpoint/restore 時間を増やさないため。

## 検証

- 計測値が 1.3〜2.0 GB/s に安定（7 GB/s スパイク消滅）。
- `black` / `isort` / `flake8` / `mypy` / `pytest`（55 passed）すべてグリーン。

close #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)