### PR TITLE
fix: record cells mixing magic lines with Python code (#17)

### DIFF
--- a/elastic_kernel/kernel.py
+++ b/elastic_kernel/kernel.py
@@ -1,3 +1,4 @@
+import ast
 import hashlib
 import json
 import logging
@@ -247,20 +248,61 @@ class ElasticKernel(IPythonKernel):
             )
             del self.shell.user_ns_hidden[variable_name]
 
-    def __skip_record(self, code):
+    # IPythonがマジック/シェルコマンドを変換した結果として現れる get_ipython() の
+    # メソッド名。これらの呼び出ししか含まないセルは「純粋なマジックセル」とみなす。
+    __MAGIC_CALL_METHODS = frozenset(
+        {"run_line_magic", "run_cell_magic", "system", "getoutput"}
+    )
+
+    @staticmethod
+    def __is_pure_magic_cell(transformed_code):
         """
-        ElasitcNotebookのrecord_eventをスキップするかどうかを判断する
+        IPythonが変換した後のコードが、マジック/シェルコマンドの呼び出しのみで
+        構成されている（=追跡対象のPythonコードを含まない）かどうかを判定する。
+
+        変換不能（SyntaxError）な場合や空セルも True（スキップ）として扱う。
         """
-        skip_magic_commands = ["!", "%", "%%"]
-        is_magic_command = any(
-            code.strip().startswith(magic) for magic in skip_magic_commands
-        )
-        if is_magic_command:
+        try:
+            tree = ast.parse(transformed_code)
+        except SyntaxError:
             return True
 
-        # TODO: bashなどpythonコードではない場合はスキップする
+        if not tree.body:
+            return True
 
-        return False
+        return all(ElasticKernel.__is_magic_statement(node) for node in tree.body)
+
+    @staticmethod
+    def __is_magic_statement(node):
+        """
+        AST ノードが get_ipython().run_line_magic(...) 等のマジック呼び出し式か判定する。
+        """
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+            return False
+        func = node.value.func
+        if (
+            not isinstance(func, ast.Attribute)
+            or func.attr not in ElasticKernel.__MAGIC_CALL_METHODS
+        ):
+            return False
+        inner = func.value
+        return (
+            isinstance(inner, ast.Call)
+            and isinstance(inner.func, ast.Name)
+            and inner.func.id == "get_ipython"
+        )
+
+    def __transform_cell(self, code):
+        """
+        IPython本体と同じ入力変換器でセルを正規のPythonコードへ変換する。
+        マジック（%, %%）やシェル（!）は get_ipython() 呼び出しへ展開されるため、
+        この結果は ast.parse 可能であり、record_event 側の解析が壊れない。
+        変換に失敗した場合は元のコードをそのまま返す。
+        """
+        try:
+            return self.shell.transform_cell(code)
+        except Exception:
+            return code
 
     async def do_execute(
         self, code, silent, store_history=True, user_expressions=None, allow_stdin=False
@@ -272,7 +314,10 @@ class ElasticKernel(IPythonKernel):
 
         self.logger.debug(f"Executing Code:\n{code}")
 
-        skip_record = self.__skip_record(code)
+        # マジック行を含むセルでも記録できるよう、IPythonの入力変換を通した
+        # 正規Pythonコードを record_event に渡す（issue #17）。
+        transformed_code = self.__transform_cell(code)
+        skip_record = self.__is_pure_magic_cell(transformed_code)
 
         pre_execution_user_ns = (
             set(self.shell.user_ns.keys()) if not skip_record else None
@@ -297,7 +342,7 @@ class ElasticKernel(IPythonKernel):
             cell_runtime = time.time() - start_time
             self.logger.debug(f"Cell runtime: {cell_runtime}")
             self.elastic_notebook.record_event(
-                code, pre_execution_user_ns, start_time, cell_runtime
+                transformed_code, pre_execution_user_ns, start_time, cell_runtime
             )
             self.logger.debug("Recording event")
 

--- a/tests/test_skip_record.py
+++ b/tests/test_skip_record.py
@@ -1,35 +1,65 @@
-"""Tests for ElasticKernel.__skip_record (magic-command skip logic).
+"""Tests for ElasticKernel's record-skip logic (issue #17).
 
-__skip_record does not use instance state, so it can be exercised via the
-name-mangled function without constructing a (heavy) kernel instance.
+The skip decision is now made by transforming the cell with IPython's input
+transformer (the same one ``InteractiveShell.transform_cell`` uses) and then
+checking, via AST analysis, whether the cell contains anything other than
+magic/shell command calls. We exercise that path here without constructing a
+(heavy) kernel instance by transforming the cell ourselves and calling the
+static analysis helper directly.
 """
+
+from IPython.core.inputtransformer2 import TransformerManager
 
 from elastic_kernel.kernel import ElasticKernel
 
-# Name-mangled access to the private method.
-_skip_record = ElasticKernel._ElasticKernel__skip_record
+# Name-mangled access to the static analysis helper.
+_is_pure_magic_cell = ElasticKernel._ElasticKernel__is_pure_magic_cell
+
+_transformer = TransformerManager()
+
+
+def _skip(code):
+    """Transform the raw cell the way the kernel does, then decide to skip."""
+    return _is_pure_magic_cell(_transformer.transform_cell(code))
 
 
 def test_shell_command_is_skipped():
-    assert _skip_record(None, "!ls -la") is True
+    assert _skip("!ls -la") is True
 
 
 def test_line_magic_is_skipped():
-    assert _skip_record(None, "%timeit foo()") is True
+    assert _skip("%timeit foo()") is True
 
 
 def test_cell_magic_is_skipped():
-    assert _skip_record(None, "%%bash\necho hi") is True
+    assert _skip("%%bash\necho hi") is True
 
 
 def test_leading_whitespace_still_skipped():
-    assert _skip_record(None, "   %matplotlib inline") is True
+    assert _skip("   %matplotlib inline") is True
 
 
 def test_plain_python_is_recorded():
-    assert _skip_record(None, "x = 1") is False
+    assert _skip("x = 1") is False
 
 
 def test_string_with_percent_inside_is_recorded():
-    # The magic check only looks at the (stripped) start of the cell.
-    assert _skip_record(None, "y = '100%'") is False
+    assert _skip("y = '100%'") is False
+
+
+def test_magic_line_mixed_with_python_is_recorded():
+    # issue #17: a magic line followed by real code must NOT skip the whole cell.
+    assert _skip("%time\na = [0] * (2 ** 25)") is False
+
+
+def test_shell_line_mixed_with_python_is_recorded():
+    assert _skip("!echo hi\nb = 42") is False
+
+
+def test_empty_cell_is_skipped():
+    assert _skip("") is True
+    assert _skip("   \n  ") is True
+
+
+def test_multiple_magics_only_is_skipped():
+    assert _skip("%matplotlib inline\n%load_ext autoreload") is True


### PR DESCRIPTION
## 概要

issue #17 の修正。`%time` のようなマジック行と通常のPythonコードが混在したセルが、これまで丸ごと記録対象外（スキップ）になっていた問題を直す。

```python
%time
a = [0] * (2 ** 25)
```

このセルは先頭が `%` で始まるため `__skip_record` が `True` を返し、変数 `a` が依存グラフに記録されず、チェックポイントにも残らなかった。

## 変更内容（案3: `transform_cell` 採用）

- 一律の「先頭文字で判定して丸ごとスキップ」をやめ、IPython本体が内部で使う入力変換器 `self.shell.transform_cell()` でセルを**正規のPythonコード**へ変換する。マジック/シェルは `get_ipython().run_line_magic(...)` などへ展開され、`ast.parse` 可能になる。
- 変換後のコードが **マジック/シェル呼び出しのみ**で構成されているかをASTで判定（`__is_pure_magic_cell`）。純粋なマジックセル（`%matplotlib inline`、`!ls` 等）のみスキップし、混在セルは記録する。
- `record_event` には変換後のコードを渡すため、`find_input_vars` の `ast.parse` が壊れなくなる。復元時は `shell.run_cell` がマジックをネイティブに扱うため整合する。
- 文字列内の `%`（例: `y = '100%'`）を誤ってマジック扱いしない堅牢性も得られる。
- 使われなくなった `__skip_record` は削除。

## テスト

`tests/test_skip_record.py` を新ロジックに合わせて更新し、混在セル・複数マジック・空セルのケースを追加。

- `uv run pytest` → 59 passed
- `uv run flake8` / `uv run mypy` → クリーン
- `uv run black` / `uv run isort` 適用済み

close #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)