### PR TITLE
fix: hash datetime64 arrays in object_hash instead of crashing

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -133,7 +133,7 @@ CI は以下の**各ライブラリについて複数の代表的なオブジェ
 | numpy | `ndarray` | ✅ | ✅ | 2.3.4 |
 |  | `structured array` | ✅ | ✅ | 2.3.4 |
 |  | `masked array` | ✅ | ✅ | 2.3.4 |
-|  | `datetime64 array` | ❌ | ❌ | 2.3.4 |
+|  | `datetime64 array` | ✅ | ✅ | 2.3.4 |
 | pandas | `DataFrame` | ✅ | ✅ | 3.0.3 |
 |  | `Series` | ✅ | ✅ | 3.0.3 |
 |  | `Series (category)` | ✅ | ✅ | 3.0.3 |

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ kept in sync by the [`library-coverage`](.github/workflows/library-coverage.yml)
 | numpy | `ndarray` | ✅ | ✅ | 2.3.4 |
 |  | `structured array` | ✅ | ✅ | 2.3.4 |
 |  | `masked array` | ✅ | ✅ | 2.3.4 |
-|  | `datetime64 array` | ❌ | ❌ | 2.3.4 |
+|  | `datetime64 array` | ✅ | ✅ | 2.3.4 |
 | pandas | `DataFrame` | ✅ | ✅ | 3.0.3 |
 |  | `Series` | ✅ | ✅ | 3.0.3 |
 |  | `Series (category)` | ✅ | ✅ | 3.0.3 |

--- a/elastic_notebook/core/mutation/object_hash.py
+++ b/elastic_notebook/core/mutation/object_hash.py
@@ -245,7 +245,17 @@ def construct_object_hash(obj, deepcopy=False):
 
     if isinstance(obj, np.ndarray):
         h = xxhash.xxh3_128()
-        h.update(np.ascontiguousarray(obj.data))
+        arr = np.ascontiguousarray(obj)
+        try:
+            # Hash the raw bytes. Viewing as uint8 lets datetime64/timedelta64 ('M'/'m')
+            # arrays be hashed too: their dtype cannot be exposed via the buffer protocol
+            # directly, which otherwise raises "cannot include dtype 'M' in a buffer"
+            # (issue #60).
+            buffer = arr.view(np.uint8)
+        except (ValueError, TypeError):
+            # Object-dtype arrays cannot be reinterpreted; hash their raw bytes instead.
+            buffer = arr.tobytes()
+        h.update(buffer)
         str1 = h.intdigest()
         return NpArrayObj(str1)
 

--- a/tests/library_specimens.py
+++ b/tests/library_specimens.py
@@ -425,9 +425,8 @@ SPECIMENS_BY_KEY = {s.key: s for s in SPECIMENS}
 # documented (shown as ❌ in the coverage table) rather than hidden, and the test gate
 # tolerates them instead of asserting success -- but the drift check still guards against
 # anything *else* regressing into this state.
-#   - numpy-datetime64: object_hash hashes the array buffer, and datetime64 ('M') arrays
-#     cannot be exposed as a buffer -> "cannot include dtype 'M' in a buffer".
-KNOWN_LIMITATIONS = {"numpy-datetime64"}
+#   (none currently -- numpy-datetime64 was fixed in #60.)
+KNOWN_LIMITATIONS: set = set()
 
 # Force the optimizer one way or the other. A near-infinite migration speed makes
 # migrating effectively free (so anything serializable is migrated); a near-zero speed

--- a/tests/test_object_hash.py
+++ b/tests/test_object_hash.py
@@ -38,6 +38,32 @@ def test_numpy_array_hash_equality():
     assert isinstance(construct_object_hash(a), NpArrayObj)
 
 
+def test_datetime64_array_hashes(profile_dict):
+    # datetime64 ('M') arrays cannot be exposed via the buffer protocol, which used to
+    # raise "cannot include dtype 'M' in a buffer" when hashing (issue #60).
+    a = np.array(["2020-01-01", "2020-06-15"], dtype="datetime64[D]")
+    b = np.array(["2020-01-01", "2020-06-15"], dtype="datetime64[D]")
+    c = np.array(["2020-01-01", "2021-06-15"], dtype="datetime64[D]")
+    assert isinstance(construct_object_hash(a), NpArrayObj)
+    assert construct_object_hash(a) == construct_object_hash(b)
+    assert construct_object_hash(a) != construct_object_hash(c)
+
+
+def test_timedelta64_array_hashes():
+    # Same buffer limitation applies to timedelta64 ('m').
+    a = np.array([1, 2, 3], dtype="timedelta64[D]")
+    b = np.array([1, 2, 4], dtype="timedelta64[D]")
+    assert isinstance(construct_object_hash(a), NpArrayObj)
+    assert construct_object_hash(a) != construct_object_hash(b)
+
+
+def test_object_dtype_array_hashes():
+    # Object-dtype arrays cannot be viewed as bytes; the tobytes() fallback keeps them
+    # from crashing the hash.
+    a = np.array([{"a": 1}, [1, 2]], dtype=object)
+    assert isinstance(construct_object_hash(a), NpArrayObj)
+
+
 def test_compare_fingerprint_no_change(profile_dict):
     x = [1, 2, 3]
     fp = construct_fingerprint(x, profile_dict)


### PR DESCRIPTION
## 概要

issue #60 の修正。numpy の `datetime64` 配列を変数に持つ状態で checkpoint しようとすると、`object_hash` のフィンガープリント計算が `ValueError: cannot include dtype 'M' in a buffer` で落ち、チェックポイントの保存・復元が失敗していた問題を修正する。

## 原因

`construct_object_hash` は ndarray のバッファ（`np.ascontiguousarray(obj.data)`）をそのまま xxhash に渡していた。`datetime64` / `timedelta64`（dtype kind `'M'` / `'m'`）の配列は buffer プロトコルで公開できないため、ここで例外になっていた。

## 修正

連続化した配列の **uint8 ビュー**（`arr.view(np.uint8)`）でrawバイトをハッシュするように変更。これにより datetime64/timedelta64 もハッシュ可能になる。reinterpret できない object 配列は `tobytes()` にフォールバック。ゼロコピー（連続時）で、既存の数値・構造化・bool 等の配列の挙動は維持。

```python
arr = np.ascontiguousarray(obj)
try:
    buffer = arr.view(np.uint8)
except (ValueError, TypeError):
    buffer = arr.tobytes()
h.update(buffer)
```

## テスト

- `tests/test_object_hash.py` に回帰テストを追加：datetime64 / timedelta64 / object 配列がクラッシュせずハッシュでき、内容差を検出できることを検証。
- #48 のカバレッジ往復で `numpy-datetime64` が **Migrate ✅ / Recompute ✅** になることを確認し、`KNOWN_LIMITATIONS` から除外。カバレッジ表も ✅ に更新（CI が自動同期）。
- ローカルで全 **84 テスト pass**（旧 datetime64 の xfailed は解消）、flake8 / mypy クリーン。

## 補足

- バグ修正のためコミット種別は `fix:`（patch バンプ）。

close #60
🤖 Generated with [Claude Code](https://claude.com/claude-code)