### PR TITLE
feat: add on-demand checkpoint/restore API for external orchestrators

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -160,6 +160,7 @@ ElasticKernel は IPython カーネルを拡張し、各セルの実行を監視
 
 ## ドキュメント
 
+- **任意タイミングのチェックポイント/復元 API:** [docs/CHECKPOINT_API.md](docs/CHECKPOINT_API.md) — 外部オーケストレーターから任意のタイミングで保存/復元を発火する（REST API）
 - **開発者向け資料:** [docs/DEVELOPERS.md](docs/DEVELOPERS.md)
 - **English README:** [README.md](README.md)
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ the migrated variables back into your namespace, and recomputes the rest.
 
 ## Documentation
 
+- **On-demand checkpoint/restore API:** [docs/CHECKPOINT_API.md](docs/CHECKPOINT_API.md) — trigger checkpoint/restore at any time from an external orchestrator (REST API)
 - **Developer guide:** [docs/DEVELOPERS.md](docs/DEVELOPERS.md)
 - **日本語 README:** [README.ja.md](README.ja.md)
 

--- a/docs/CHECKPOINT_API.md
+++ b/docs/CHECKPOINT_API.md
@@ -1,0 +1,147 @@
+# 任意タイミングのチェックポイント / 復元 API
+
+ElasticKernel は通常、**カーネルの停止時にチェックポイントを保存**し、**起動時に復元**する。
+これに加えて、外部のオーケストレーションシステムから **任意のタイミングで保存 / 復元を発火**
+できる API を提供する。
+
+- 発火は外部からの明示指示のみ（タイマーや自動発火ではない）。
+- ノートブックのエンドユーザーには**透過**（マジックコマンド不要・`user_ns` や `%who` を汚さない）。
+- 保存処理はカーネルのメインループに乗せて実行されるため、走行中のセルと競合せず一貫した
+  スナップショットになる。
+
+仕組みは2層に分かれる:
+
+```
+外部オーケストレーター
+   │  HTTP POST /elastic_kernel/checkpoint  {kernel_id}
+   ▼
+Jupyter Server 拡張（カーネルと同一ホストで同居）
+   │  control チャネルに custom message
+   ▼
+カーネル本体  →  チェックポイント保存 / 復元
+   ▼
+   結果(JSON)を HTTP レスポンスとして返す
+```
+
+---
+
+## 有効化
+
+REST API はオプトイン。デフォルトでは無効。
+
+```sh
+# 依存込みでインストール（jupyter_server を含む）
+pip install "elastic-kernel[server]"
+
+# カーネル登録に加えて REST API（Jupyter Server 拡張）を有効化
+elastic-kernel install --server
+```
+
+`elastic-kernel install`（`--server` なし）の場合はカーネルのみ登録され、REST API は無効のまま。
+
+有効化の確認:
+
+```sh
+jupyter server extension list
+# elastic_kernel.serverextension  enabled  OK
+```
+
+無効化:
+
+```sh
+jupyter server extension disable elastic_kernel.serverextension
+```
+
+---
+
+## エンドポイント
+
+いずれも `POST`。Jupyter Server のトークン認証を使うため、`Authorization: token <TOKEN>`
+ヘッダを付ける（トークン認証なら XSRF ヘッダは不要）。
+
+| メソッド・パス | 説明 |
+| --- | --- |
+| `POST /elastic_kernel/checkpoint` | 対象カーネルの現在の状態を保存する |
+| `POST /elastic_kernel/restore` | 対象カーネルをチェックポイントから復元する（**破壊的**: `user_ns` を上書きする） |
+
+### リクエストボディ（JSON）
+
+| フィールド | 必須 | 説明 |
+| --- | --- | --- |
+| `kernel_id` | ○ | 対象カーネルの ID。`GET /api/kernels` や `GET /api/sessions` から取得する |
+| `timeout` | – | カーネルからの応答を待つ秒数（デフォルト 120） |
+
+### レスポンス
+
+| ステータス | 意味 |
+| --- | --- |
+| `200` | 成功。ボディは `{"ok": true, "elapsed_seconds": ..., "path": ..., ...}` |
+| `409` | カーネルは生きているが実行できない（`plain_kernel_mode` / `no_checkpoint_file` / `exception`）。ボディの `reason` を参照 |
+| `400` | `kernel_id` 欠落、または `timeout` が不正 |
+| `403` | 認証トークンが無い／不正 |
+| `404` | `kernel_id` に対応するカーネルが存在しない |
+| `504` | カーネルが時間内に応答しなかった（例: 長時間ブロックするセルが実行中） |
+
+保存成功時のボディ例:
+
+```json
+{
+  "ok": true,
+  "elapsed_seconds": 0.052,
+  "path": "/work/.elastic_kernel/<hash>/checkpoint.pickle",
+  "vss_to_migrate": 3,
+  "vss_to_recompute": 0
+}
+```
+
+---
+
+## 使用例
+
+```sh
+TOK="<jupyter token>"
+BASE="http://127.0.0.1:8888"
+
+# 1) kernel_id を調べる（ノートブックとカーネルの対応は /api/sessions が分かりやすい）
+curl -s -H "Authorization: token $TOK" "$BASE/api/sessions"
+
+# 2) 保存
+curl -s -X POST \
+  -H "Authorization: token $TOK" -H "Content-Type: application/json" \
+  -d '{"kernel_id":"<ID>"}' \
+  "$BASE/elastic_kernel/checkpoint"
+
+# 3) 復元
+curl -s -X POST \
+  -H "Authorization: token $TOK" -H "Content-Type: application/json" \
+  -d '{"kernel_id":"<ID>"}' \
+  "$BASE/elastic_kernel/restore"
+```
+
+> **注意（復元の破壊性）**: `restore` はカーネルの現在の名前空間を上書きし、必要なセルを
+> 再計算する。どのタイミングで誰のカーネルに対して発火するかはオーケストレーター側の責務。
+
+---
+
+## サーバー拡張を使わない方法（control チャネル直送）
+
+オーケストレーターがカーネルと**同一ホスト**にあり、カーネルの接続ファイルを読める場合は、
+Jupyter Server 拡張を介さず `jupyter_client` で control チャネルへ直接メッセージを送ることも
+できる（control チャネルのハンドラはサーバー拡張の有効・無効に関わらず常に登録されている）。
+
+```python
+from jupyter_client import BlockingKernelClient
+
+client = BlockingKernelClient()
+client.load_connection_file("<jupyter runtime dir>/kernel-<kernel_id>.json")
+client.start_channels()
+
+msg = client.session.msg("elastic_checkpoint_request", {})  # 復元は elastic_restore_request
+client.control_channel.send(msg)
+print(client.get_control_msg(timeout=120)["content"])       # {"ok": True, ...}
+
+client.stop_channels()
+```
+
+別ホストから操作する場合はカーネルの ZMQ ポートがネットワークに露出していないため、この方法は
+使えない。HTTP（Jupyter Server のポート）経由の REST API を使うこと。

--- a/elastic_kernel/command.py
+++ b/elastic_kernel/command.py
@@ -22,11 +22,44 @@ def install_kernel():
     return True
 
 
+def enable_server_extension():
+    """外部オーケストレーター向け REST API（Jupyter Server 拡張）を有効化する。
+
+    拡張の有効化は jpserver_extensions config の書き込みで決まるため、
+    toggle_server_extension_python で sys.prefix 配下の config に書き込む。
+    jupyter_server が未導入の場合は extras の案内をして False を返す。
+    """
+    try:
+        from jupyter_server.extension.serverextension import (
+            toggle_server_extension_python,
+        )
+    except ImportError:
+        print(
+            "jupyter_server がインストールされていません。"
+            "REST API を使うには `pip install elastic_kernel[server]` を実行してください。",
+            file=sys.stderr,
+        )
+        return False
+
+    toggle_server_extension_python(
+        "elastic_kernel.serverextension", enabled=True, sys_prefix=True
+    )
+    print(
+        "Elastic Kernel server extension enabled "
+        "(POST /elastic_kernel/checkpoint, /restore)."
+    )
+    return True
+
+
 def main():
-    if len(sys.argv) > 1 and sys.argv[1] == "install":
+    args = sys.argv[1:]
+    if args and args[0] == "install":
         install_kernel()
+        # `--server` 指定時のみ REST API（サーバー拡張）も有効化する。
+        if "--server" in args[1:]:
+            enable_server_extension()
     else:
-        print("Usage: elastic-kernel install", file=sys.stderr)
+        print("Usage: elastic-kernel install [--server]", file=sys.stderr)
         sys.exit(1)
 
 

--- a/elastic_kernel/kernel.py
+++ b/elastic_kernel/kernel.py
@@ -435,23 +435,44 @@ class ElasticKernel(IPythonKernel):
 
     async def _run_on_main_loop(self, fn):
         """
-        fn() をメインの shell io_loop（セルが実行されるループ）上で実行し、その結果を await する。
+        同期関数 fn() を「メインの shell io_loop」上で実行し、その戻り値を await して返す。
 
-        control ハンドラは control 用のループ/スレッドで動くため、そこから直接 user_ns を
-        触るとセル実行とのデータ競合になる。メイン io_loop へ marshal することで、走行中の
-        セルが終わってから（＝user_ns と排他な状態で）実行され、一貫したスナップショットになる。
+        なぜこれが必要か（スレッドの住み分け）:
+        - ipykernel では、セル実行 (do_execute) は「メインの shell io_loop」スレッドで動く。
+        - 一方、control チャネルのメッセージ（このハンドラ）は「別の control スレッド」で動く。
+        - fn には _save_checkpoint / _restore_checkpoint が渡される。これらは self.shell.user_ns
+          を読み書きするが、user_ns はセル実行が触っている本体そのもの。control スレッドから
+          直接呼ぶと、セル実行中の user_ns を別スレッドが同時に触ることになり、データ競合や
+          「半分だけ更新された状態」のスナップショットを生む。
+
+        そこで fn を直接呼ばず、メイン io_loop に「あとで実行して」と予約 (add_callback) する。
+        メイン io_loop はセル実行と同じ場所なので、予約された fn は「実行中のセルが無い瞬間」に
+        順番が回ってきて実行される。結果として user_ns と排他な状態で保存/復元でき、一貫性が保たれる。
+
+        実装:
+        1. asyncio の Future を control 側ループに作る（fn の完了を待つための受け皿）。
+        2. fn を包んだ _runner をメイン io_loop に予約する。_runner はメインスレッドで動く。
+        3. _runner は fn() の結果（or 例外）を call_soon_threadsafe で control 側ループの Future に
+           渡す（スレッドをまたぐので threadsafe 版を使う）。
+        4. await fut で、メイン側の fn() が終わるまでこの control ハンドラを中断して待つ。
         """
-        loop = asyncio.get_running_loop()  # control 側のループ
+        # このコルーチンが動いている control 側のイベントループ。Future の所有者になる。
+        loop = asyncio.get_running_loop()
         fut = loop.create_future()
 
         def _runner():
+            # ここはメイン io_loop スレッド上。セル実行と排他なので user_ns を安全に触れる。
             try:
                 result = fn()
+                # 別スレッド(control側)の Future へ結果を渡す。threadsafe でないと壊れる。
                 loop.call_soon_threadsafe(fut.set_result, result)
-            except Exception as e:  # 例外をメインループ上に漏らさない
+            except (
+                Exception
+            ) as e:  # メインループ上に例外を漏らさず Future 経由で伝播させる。
                 loop.call_soon_threadsafe(fut.set_exception, e)
 
-        # add_callback はスレッドセーフ。メイン io_loop が idle になったとき _runner を実行する。
+        # add_callback はスレッドセーフ。メイン io_loop の手が空いたとき（=実行中セルが無い瞬間）に
+        # _runner を実行する。control スレッドからメインスレッドへ処理を「橋渡し」している。
         self.io_loop.add_callback(_runner)
         return await fut
 

--- a/elastic_kernel/kernel.py
+++ b/elastic_kernel/kernel.py
@@ -1,4 +1,5 @@
 import ast
+import asyncio
 import hashlib
 import json
 import logging
@@ -74,42 +75,19 @@ class ElasticKernel(IPythonKernel):
                 "Continuing without checkpoint tracking (plain kernel mode)."
             )
 
-        # チェックポイントファイルをロードする
-        if self.elastic_notebook is not None and os.path.exists(
-            self.checkpoint_file_path
-        ):
-            self.logger.info("Checkpoint file exists. Loading checkpoint.")
-            try:
-                start_time = datetime.now(timezone(timedelta(hours=9))).strftime(
-                    "%Y-%m-%dT%H:%M:%S.%f%z"
-                )
-                self.logger.debug(f"{self.shell.user_ns=}")
-                self.logger.info(f"Loading checkpoint started at: {start_time}")
+        # 起動時にチェックポイントファイルがあれば復元する。
+        # 復元ロジックは _restore_checkpoint() に共通化されており、外部オーケストレーター
+        # からの control メッセージ経由でも同じ処理を再利用する。
+        self._restore_checkpoint()
 
-                self.elastic_notebook.load_checkpoint(self.checkpoint_file_path)
-
-                end_time = datetime.now(timezone(timedelta(hours=9))).strftime(
-                    "%Y-%m-%dT%H:%M:%S.%f%z"
-                )
-                loading_time = datetime.strptime(
-                    end_time, "%Y-%m-%dT%H:%M:%S.%f%z"
-                ) - datetime.strptime(start_time, "%Y-%m-%dT%H:%M:%S.%f%z")
-                self.logger.info(f"Loading checkpoint finished at: {end_time}")
-                self.logger.info(f"Total loading time: {loading_time}")
-                self.logger.debug(f"{self.shell.user_ns=}")
-
-                self.logger.debug(
-                    f"{self.elastic_notebook.dependency_graph.variable_snapshots=}"
-                )
-                self.logger.info("Checkpoint successfully loaded.")
-
-            except Exception as e:
-                self.logger.error(f"Error loading checkpoint: {e}")
-                self.logger.error(f"Error details:\n{traceback.format_exc()}")
-        else:
-            self.logger.info(
-                "Checkpoint file does not exist. Skipping loading checkpoint."
-            )
+        # 外部オーケストレーターから任意タイミングで保存/復元を発火できるよう、control
+        # チャネルにカスタムメッセージハンドラを登録する。control チャネルはセル実行の
+        # shell キューとは別系統なので、実行中でも割り込んで処理でき、user_ns にコードを
+        # 走らせないためノートブックユーザーには透過（%who を汚染しない）。
+        self.control_handlers["elastic_checkpoint_request"] = (
+            self._on_checkpoint_request
+        )
+        self.control_handlers["elastic_restore_request"] = self._on_restore_request
 
     def __resolve_path_without_jpy_session_name(self):
         """
@@ -348,15 +326,69 @@ class ElasticKernel(IPythonKernel):
 
         return result
 
-    def do_shutdown(self, restart):
+    def _restore_checkpoint(self):
         """
-        カーネル終了時に呼び出されるメソッド
+        self.checkpoint_file_path からチェックポイントを復元する。
+
+        起動時（__init__）と、外部オーケストレーターからの control メッセージの両方から
+        呼ばれる共通ロジック。再呼び出し可能（冪等）。結果を dict で返す。
+
+        注意: load_checkpoint は user_ns を上書き・セルを再計算する破壊的操作。発火順序の
+        管理は呼び出し側（オーケストレーター）の責務。
         """
-        # ElasticNotebook の生成に失敗していた場合はチェックポイントを保存できないので
-        # スキップして通常のシャットダウンを継続する。(D-13)
+        if self.elastic_notebook is None:
+            self.logger.info("ElasticNotebook unavailable; cannot restore checkpoint.")
+            return {"ok": False, "reason": "plain_kernel_mode"}
+        if not os.path.exists(self.checkpoint_file_path):
+            self.logger.info(
+                "Checkpoint file does not exist. Skipping loading checkpoint."
+            )
+            return {"ok": False, "reason": "no_checkpoint_file"}
+
+        self.logger.info("Checkpoint file exists. Loading checkpoint.")
+        try:
+            start_time = datetime.now(timezone(timedelta(hours=9))).strftime(
+                "%Y-%m-%dT%H:%M:%S.%f%z"
+            )
+            self.logger.debug(f"{self.shell.user_ns=}")
+            self.logger.info(f"Loading checkpoint started at: {start_time}")
+
+            self.elastic_notebook.load_checkpoint(self.checkpoint_file_path)
+
+            end_time = datetime.now(timezone(timedelta(hours=9))).strftime(
+                "%Y-%m-%dT%H:%M:%S.%f%z"
+            )
+            loading_time = datetime.strptime(
+                end_time, "%Y-%m-%dT%H:%M:%S.%f%z"
+            ) - datetime.strptime(start_time, "%Y-%m-%dT%H:%M:%S.%f%z")
+            self.logger.info(f"Loading checkpoint finished at: {end_time}")
+            self.logger.info(f"Total loading time: {loading_time}")
+            self.logger.debug(f"{self.shell.user_ns=}")
+            self.logger.debug(
+                f"{self.elastic_notebook.dependency_graph.variable_snapshots=}"
+            )
+            self.logger.info("Checkpoint successfully loaded.")
+            return {
+                "ok": True,
+                "elapsed_seconds": loading_time.total_seconds(),
+                "path": self.checkpoint_file_path,
+            }
+        except Exception as e:
+            self.logger.error(f"Error loading checkpoint: {e}")
+            self.logger.error(f"Error details:\n{traceback.format_exc()}")
+            return {"ok": False, "reason": "exception", "error": str(e)}
+
+    def _save_checkpoint(self):
+        """
+        self.checkpoint_file_path へチェックポイントを保存する。
+
+        カーネル終了時（do_shutdown）と、外部オーケストレーターからの control メッセージの
+        両方から呼ばれる共通ロジック。再呼び出し可能（冪等）。結果を dict で返す。
+        """
+        # ElasticNotebook の生成に失敗していた場合はチェックポイントを保存できない。(D-13)
         if self.elastic_notebook is None:
             self.logger.info("ElasticNotebook unavailable; skipping checkpoint save.")
-            return super().do_shutdown(restart)
+            return {"ok": False, "reason": "plain_kernel_mode"}
 
         try:
             start_time = datetime.now(timezone(timedelta(hours=9))).strftime(
@@ -388,10 +420,78 @@ class ElasticKernel(IPythonKernel):
             self.logger.debug(
                 f"再計算する変数：{self.elastic_notebook.vss_to_recompute}"
             )
+            return {
+                "ok": True,
+                "elapsed_seconds": saving_time.total_seconds(),
+                "path": self.checkpoint_file_path,
+                "vss_to_migrate": len(self.elastic_notebook.vss_to_migrate),
+                "vss_to_recompute": len(self.elastic_notebook.vss_to_recompute),
+            }
 
         except Exception as e:
             self.logger.error(f"Error saving checkpoint: {e}")
             self.logger.error(f"Error details:\n{traceback.format_exc()}")
+            return {"ok": False, "reason": "exception", "error": str(e)}
+
+    async def _run_on_main_loop(self, fn):
+        """
+        fn() をメインの shell io_loop（セルが実行されるループ）上で実行し、その結果を await する。
+
+        control ハンドラは control 用のループ/スレッドで動くため、そこから直接 user_ns を
+        触るとセル実行とのデータ競合になる。メイン io_loop へ marshal することで、走行中の
+        セルが終わってから（＝user_ns と排他な状態で）実行され、一貫したスナップショットになる。
+        """
+        loop = asyncio.get_running_loop()  # control 側のループ
+        fut = loop.create_future()
+
+        def _runner():
+            try:
+                result = fn()
+                loop.call_soon_threadsafe(fut.set_result, result)
+            except Exception as e:  # 例外をメインループ上に漏らさない
+                loop.call_soon_threadsafe(fut.set_exception, e)
+
+        # add_callback はスレッドセーフ。メイン io_loop が idle になったとき _runner を実行する。
+        self.io_loop.add_callback(_runner)
+        return await fut
+
+    async def _on_checkpoint_request(self, stream, idents, parent):
+        """control チャネルの elastic_checkpoint_request ハンドラ。"""
+        self.logger.info("Received elastic_checkpoint_request (control channel)")
+        try:
+            result = await self._run_on_main_loop(self._save_checkpoint)
+        except Exception as e:
+            result = {"ok": False, "reason": "exception", "error": str(e)}
+        self.session.send(
+            stream,
+            "elastic_checkpoint_reply",
+            content=result,
+            parent=parent,
+            ident=idents,
+        )
+
+    async def _on_restore_request(self, stream, idents, parent):
+        """control チャネルの elastic_restore_request ハンドラ。"""
+        self.logger.info("Received elastic_restore_request (control channel)")
+        try:
+            result = await self._run_on_main_loop(self._restore_checkpoint)
+        except Exception as e:
+            result = {"ok": False, "reason": "exception", "error": str(e)}
+        self.session.send(
+            stream,
+            "elastic_restore_reply",
+            content=result,
+            parent=parent,
+            ident=idents,
+        )
+
+    def do_shutdown(self, restart):
+        """
+        カーネル終了時に呼び出されるメソッド
+        """
+        # 保存ロジックは _save_checkpoint() に共通化。plain-kernel モードの判定もこの中で行い、
+        # いずれの場合も通常のシャットダウンを継続する。(D-13)
+        self._save_checkpoint()
         return super().do_shutdown(restart)
 
 

--- a/elastic_kernel/serverextension.py
+++ b/elastic_kernel/serverextension.py
@@ -1,0 +1,121 @@
+"""Jupyter Server 拡張: 外部オーケストレーター向けの REST チェックポイント/復元 API。
+
+このモジュールは Jupyter Server（JupyterLab の裏で動く Web サーバー）に
+``POST /elastic_kernel/checkpoint`` と ``POST /elastic_kernel/restore`` の2つの
+エンドポイントを追加する。リクエストは ``kernel_id`` で対象カーネルを指定し、ハンドラは
+そのカーネルの control チャネルへカスタムメッセージ（``elastic_checkpoint_request`` /
+``elastic_restore_request``）を送り、カーネル側（elastic_kernel.kernel）が返す reply を
+HTTP レスポンスとして中継する。
+
+注意:
+- このモジュールは Jupyter Server プロセス側でのみロードされる。カーネルプロセスからは
+  import されない（kernel.py は jupyter_server に依存しない）。
+- 有効化は ``elastic-kernel install --server``（toggle_server_extension_python 経由）で行う。
+  そのため常時 ON の jupyter_server_config.d JSON は同梱していない。
+"""
+
+import json
+import time
+from queue import Empty
+
+from jupyter_server.base.handlers import APIHandler
+from jupyter_server.utils import url_path_join
+from tornado import web
+
+# control チャネルへ送るリクエスト種別と、対応する reply 種別。
+_CHECKPOINT = ("elastic_checkpoint_request", "elastic_checkpoint_reply")
+_RESTORE = ("elastic_restore_request", "elastic_restore_reply")
+
+# reply を待つデフォルトのタイムアウト（秒）。body の "timeout" で上書き可。
+_DEFAULT_TIMEOUT = 120.0
+
+
+async def _send_and_await(kernel, request_type, reply_type, timeout):
+    """対象カーネルの control チャネルへ request_type を送り、reply_type を await して返す。
+
+    新しいクライアント（= JupyterLab とは別の接続）を一時的に開いて control チャネルに
+    送る。control チャネルは複数クライアント可で、reply は送信元へルーティングされる。
+    クライアントは km.client() で生成されるため署名キーがカーネルと一致する。
+    """
+    client = kernel.client()
+    client.start_channels()
+    try:
+        msg = client.session.msg(request_type, {})
+        msg_id = msg["header"]["msg_id"]
+        client.control_channel.send(msg)
+
+        # reply は parent_header.msg_id が一致する control メッセージ。状態通知などが
+        # 紛れ込んでも取り違えないよう、msg_id と msg_type で照合する。
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"timeout waiting for {reply_type}")
+            reply = await client.get_control_msg(timeout=remaining)
+            if (
+                reply.get("msg_type") == reply_type
+                and reply.get("parent_header", {}).get("msg_id") == msg_id
+            ):
+                return reply["content"]
+    finally:
+        client.stop_channels()
+
+
+class _ElasticBaseHandler(APIHandler):
+    """checkpoint/restore 共通の処理。kernel_id 解決 → control 送信 → JSON 応答。"""
+
+    async def _dispatch(self, request_type, reply_type):
+        body = self.get_json_body() or {}
+        kernel_id = body.get("kernel_id") or self.get_argument("kernel_id", None)
+        if not kernel_id:
+            raise web.HTTPError(400, "kernel_id is required")
+
+        try:
+            kernel = self.kernel_manager.get_kernel(kernel_id)
+        except KeyError:
+            raise web.HTTPError(404, f"unknown kernel_id: {kernel_id}")
+
+        try:
+            timeout = float(body.get("timeout", _DEFAULT_TIMEOUT))
+        except (TypeError, ValueError):
+            raise web.HTTPError(400, "timeout must be a number")
+
+        try:
+            content = await _send_and_await(kernel, request_type, reply_type, timeout)
+        except (TimeoutError, Empty):
+            raise web.HTTPError(504, "kernel did not reply in time")
+
+        # ok=True は 200、ok=False（plain_kernel_mode / no_checkpoint_file / exception）は 409。
+        self.set_status(200 if content.get("ok") else 409)
+        self.finish(json.dumps(content))
+
+
+class CheckpointHandler(_ElasticBaseHandler):
+    @web.authenticated
+    async def post(self):
+        await self._dispatch(*_CHECKPOINT)
+
+
+class RestoreHandler(_ElasticBaseHandler):
+    @web.authenticated
+    async def post(self):
+        await self._dispatch(*_RESTORE)
+
+
+def _jupyter_server_extension_points():
+    return [{"module": "elastic_kernel.serverextension"}]
+
+
+def _load_jupyter_server_extension(server_app):
+    """Jupyter Server 起動時に呼ばれ、エンドポイントを登録する。"""
+    web_app = server_app.web_app
+    base_url = web_app.settings["base_url"]
+    handlers = [
+        (url_path_join(base_url, "elastic_kernel", "checkpoint"), CheckpointHandler),
+        (url_path_join(base_url, "elastic_kernel", "restore"), RestoreHandler),
+    ]
+    web_app.add_handlers(".*$", handlers)
+    server_app.log.info(
+        "elastic_kernel server extension loaded: "
+        "POST /elastic_kernel/checkpoint, POST /elastic_kernel/restore"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,12 @@ classifiers = [
     "Framework :: Jupyter",
 ]
 
+[project.optional-dependencies]
+# 外部オーケストレーター向け REST チェックポイント/復元 API（Jupyter Server 拡張）。
+# jupyter_server は JupyterLab 環境には通常既に入っているが、この機能を使う意図を明示し
+# 保証するため optional-dependencies に置く。有効化は `elastic-kernel install --server`。
+server = ["jupyter_server"]
+
 [project.urls]
 Homepage = "https://github.com/MRyutaro/ElasticKernel"
 Repository = "https://github.com/MRyutaro/ElasticKernel"

--- a/tests/test_checkpoint_control.py
+++ b/tests/test_checkpoint_control.py
@@ -1,0 +1,233 @@
+"""Tests for on-demand checkpoint/restore wiring (issue: external orchestrator API).
+
+Covers the kernel-side refactor (_save_checkpoint / _restore_checkpoint), the
+control-channel handlers, and the server-extension registration. The methods are
+exercised against lightweight stub ``self`` objects so we never spin up a real
+IPythonKernel (which needs a connection file and a live ZMQ stack).
+"""
+
+import asyncio
+import inspect
+import logging
+import types
+
+import pytest
+
+from elastic_kernel.kernel import ElasticKernel
+
+
+class _StubNotebook:
+    """Minimal stand-in for ElasticNotebook used by save/restore."""
+
+    def __init__(self):
+        self.vss_to_migrate = ["a", "b"]
+        self.vss_to_recompute = ["c"]
+        self.checkpoint_calls = []
+        self.load_calls = []
+        self.dependency_graph = types.SimpleNamespace(variable_snapshots={})
+
+    def checkpoint(self, path):
+        self.checkpoint_calls.append(path)
+
+    def load_checkpoint(self, path):
+        self.load_calls.append(path)
+
+
+def _stub_self(elastic_notebook, checkpoint_file_path):
+    """A bare object carrying only the attributes save/restore touch."""
+    return types.SimpleNamespace(
+        logger=logging.getLogger("elastic-test"),
+        elastic_notebook=elastic_notebook,
+        checkpoint_file_path=checkpoint_file_path,
+        shell=types.SimpleNamespace(user_ns={}),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _save_checkpoint
+# --------------------------------------------------------------------------- #
+def test_save_plain_kernel_mode():
+    s = _stub_self(None, "/nonexistent/checkpoint.pickle")
+    assert ElasticKernel._save_checkpoint(s) == {
+        "ok": False,
+        "reason": "plain_kernel_mode",
+    }
+
+
+def test_save_success(tmp_path):
+    nb = _StubNotebook()
+    path = str(tmp_path / "checkpoint.pickle")
+    s = _stub_self(nb, path)
+
+    result = ElasticKernel._save_checkpoint(s)
+
+    assert result["ok"] is True
+    assert result["path"] == path
+    assert result["vss_to_migrate"] == 2
+    assert result["vss_to_recompute"] == 1
+    assert "elapsed_seconds" in result
+    assert nb.checkpoint_calls == [path]
+
+
+def test_save_exception_is_caught(tmp_path):
+    nb = _StubNotebook()
+
+    def _boom(_path):
+        raise RuntimeError("disk full")
+
+    nb.checkpoint = _boom
+    s = _stub_self(nb, str(tmp_path / "checkpoint.pickle"))
+
+    result = ElasticKernel._save_checkpoint(s)
+
+    assert result["ok"] is False
+    assert result["reason"] == "exception"
+    assert "disk full" in result["error"]
+
+
+# --------------------------------------------------------------------------- #
+# _restore_checkpoint
+# --------------------------------------------------------------------------- #
+def test_restore_plain_kernel_mode():
+    s = _stub_self(None, "/whatever/checkpoint.pickle")
+    assert ElasticKernel._restore_checkpoint(s) == {
+        "ok": False,
+        "reason": "plain_kernel_mode",
+    }
+
+
+def test_restore_no_checkpoint_file(tmp_path):
+    nb = _StubNotebook()
+    s = _stub_self(nb, str(tmp_path / "missing.pickle"))
+
+    result = ElasticKernel._restore_checkpoint(s)
+
+    assert result == {"ok": False, "reason": "no_checkpoint_file"}
+    assert nb.load_calls == []
+
+
+def test_restore_success(tmp_path):
+    nb = _StubNotebook()
+    path = tmp_path / "checkpoint.pickle"
+    path.write_bytes(b"x")  # only needs to exist
+    s = _stub_self(nb, str(path))
+
+    result = ElasticKernel._restore_checkpoint(s)
+
+    assert result["ok"] is True
+    assert result["path"] == str(path)
+    assert nb.load_calls == [str(path)]
+
+
+# --------------------------------------------------------------------------- #
+# control-channel handlers
+# --------------------------------------------------------------------------- #
+def test_control_handlers_are_coroutines():
+    assert inspect.iscoroutinefunction(ElasticKernel._on_checkpoint_request)
+    assert inspect.iscoroutinefunction(ElasticKernel._on_restore_request)
+
+
+class _FakeIOLoop:
+    """Marshals add_callback onto the running asyncio loop (mimics the main loop)."""
+
+    def __init__(self, loop):
+        self._loop = loop
+
+    def add_callback(self, fn):
+        self._loop.call_soon(fn)
+
+
+def _run_handler(handler, s):
+    """Drive an async control handler to completion via asyncio.run()."""
+
+    async def _run():
+        loop = asyncio.get_running_loop()
+        s.io_loop = _FakeIOLoop(loop)
+        # Bind the real helpers onto the stub so the handler can reuse them.
+        s._save_checkpoint = lambda: ElasticKernel._save_checkpoint(s)
+        s._restore_checkpoint = lambda: ElasticKernel._restore_checkpoint(s)
+        s._run_on_main_loop = lambda fn: ElasticKernel._run_on_main_loop(s, fn)
+        await handler(s, "stream", b"ident", {"header": {"msg_id": "req-1"}})
+
+    asyncio.run(_run())
+
+
+def test_checkpoint_handler_sends_reply(tmp_path):
+    nb = _StubNotebook()
+    path = str(tmp_path / "checkpoint.pickle")
+    sent = []
+
+    s = _stub_self(nb, path)
+    s.session = types.SimpleNamespace(
+        send=lambda stream, msg_type, content, parent, ident: sent.append(
+            (msg_type, content, parent, ident)
+        )
+    )
+
+    _run_handler(ElasticKernel._on_checkpoint_request, s)
+
+    assert len(sent) == 1
+    msg_type, content, parent, ident = sent[0]
+    assert msg_type == "elastic_checkpoint_reply"
+    assert content["ok"] is True
+    assert parent == {"header": {"msg_id": "req-1"}}
+    assert ident == b"ident"
+    # The save actually ran on the (faked) main loop.
+    assert nb.checkpoint_calls == [path]
+
+
+def test_restore_handler_sends_reply(tmp_path):
+    nb = _StubNotebook()
+    path = tmp_path / "checkpoint.pickle"
+    path.write_bytes(b"x")
+    sent = []
+
+    s = _stub_self(nb, str(path))
+    s.session = types.SimpleNamespace(
+        send=lambda stream, msg_type, content, parent, ident: sent.append(
+            (msg_type, content)
+        )
+    )
+
+    _run_handler(ElasticKernel._on_restore_request, s)
+
+    assert len(sent) == 1
+    msg_type, content = sent[0]
+    assert msg_type == "elastic_restore_reply"
+    assert content["ok"] is True
+    assert nb.load_calls == [str(path)]
+
+
+# --------------------------------------------------------------------------- #
+# server extension
+# --------------------------------------------------------------------------- #
+def test_server_extension_points():
+    pytest.importorskip("jupyter_server")
+    from elastic_kernel import serverextension
+
+    assert serverextension._jupyter_server_extension_points() == [
+        {"module": "elastic_kernel.serverextension"}
+    ]
+
+
+def test_load_registers_handlers():
+    pytest.importorskip("jupyter_server")
+    from elastic_kernel import serverextension
+
+    registered = []
+
+    class _FakeWebApp:
+        settings = {"base_url": "/"}
+
+        def add_handlers(self, host_pattern, handlers):
+            registered.extend(handlers)
+
+    fake_app = types.SimpleNamespace(
+        web_app=_FakeWebApp(), log=logging.getLogger("test")
+    )
+
+    serverextension._load_jupyter_server_extension(fake_app)
+
+    paths = [pattern for pattern, _handler in registered]
+    assert any("checkpoint" in p for p in paths)
+    assert any("restore" in p for p in paths)

--- a/uv.lock
+++ b/uv.lock
@@ -865,7 +865,7 @@ wheels = [
 
 [[package]]
 name = "elastic-kernel"
-version = "0.0.33"
+version = "0.0.34"
 source = { editable = "." }
 dependencies = [
     { name = "dill" },
@@ -883,6 +883,11 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "xxhash" },
+]
+
+[package.optional-dependencies]
+server = [
+    { name = "jupyter-server" },
 ]
 
 [package.dev-dependencies]
@@ -921,10 +926,12 @@ requires-dist = [
     { name = "ipython" },
     { name = "jupyter" },
     { name = "jupyter-client" },
+    { name = "jupyter-server", marker = "extra == 'server'" },
     { name = "networkx" },
     { name = "numpy" },
     { name = "xxhash" },
 ]
+provides-extras = ["server"]
 
 [package.metadata.requires-dev]
 coverage = [


### PR DESCRIPTION
## 概要

カーネルの**起動/停止時だけ**だったチェックポイント保存/復元を、**外部オーケストレーターから任意タイミングで発火**できるようにする。発火は外部からの明示指示のみで、ノートブックのエンドユーザーには**透過**（マジックコマンド不要・`user_ns`/`%who` を汚さない）。

## 動機

別途構築する外部オーケストレーションシステムが、稼働中の特定カーネルの状態を任意のタイミングでスナップショット/復元したい、というユースケースに対応する。

## アーキテクチャ

```
外部オーケストレーター
   │  HTTP POST /elastic_kernel/checkpoint  {kernel_id}
   ▼
Jupyter Server 拡張 (serverextension.py)   ← 同一ホストでカーネルと同居
   │  control チャネルに custom message (elastic_checkpoint_request)
   ▼
カーネル (kernel.py)  control_handlers → メイン io_loop に marshal → _save_checkpoint()
   ▼
   reply (ok / elapsed / vss数) を HTTP レスポンスで返す
```

- **control チャネル**採用: ユーザーのセル実行キューに並ばず即処理でき、`user_ns` にコードを走らせないため透過。
- 実処理は**メイン io_loop へ marshal** し、走行中セルとの `user_ns` 競合を回避（一貫したスナップショット）。

## 変更点

- **`elastic_kernel/kernel.py`**: 保存/復元ロジックを `_save_checkpoint` / `_restore_checkpoint` に共通化（`do_shutdown` / `__init__` からも再利用）。control チャネルに `elastic_checkpoint_request` / `elastic_restore_request` ハンドラを登録。`_run_on_main_loop` でメインループへ marshal。
- **`elastic_kernel/serverextension.py`**（新規）: Jupyter Server 拡張。`POST /elastic_kernel/checkpoint`・`/restore` を提供し、`kernel_id` 指定でカーネルの control チャネルへ橋渡し、reply を JSON で中継。`kernel.py` からは `jupyter_server` を import しない（カーネルプロセスは非依存）。
- **`elastic_kernel/command.py`**: `elastic-kernel install --server` で拡張を有効化（`toggle_server_extension_python`）。`jupyter_server` 未導入なら extras を案内。
- **`pyproject.toml`**: `optional-dependencies` に `server = ["jupyter_server"]` を追加。

## 切り分け（インストール）

REST API は**オプトイン**。常時 ON の `jupyter_server_config.d` JSON は同梱せず、有効化はコマンド経由:

| コマンド | 効果 |
|---|---|
| `elastic-kernel install` | カーネルspecのみ（REST API は OFF） |
| `elastic-kernel install --server` | 加えてサーバー拡張を有効化（REST API ON） |

OFF に戻す: `jupyter server extension disable elastic_kernel.serverextension`

## 使い方（外部オーケストレーター側）

```bash
# kernel_id は /api/kernels や /api/sessions から取得
curl -X POST -H "Authorization: token $TOK" -H "Content-Type: application/json" \
  -d '{"kernel_id":"<ID>"}' http://127.0.0.1:8888/elastic_kernel/checkpoint
# -> {"ok": true, "elapsed_seconds": ..., "vss_to_migrate": N, ...}
```

レスポンス: 成功 `200 ok:true` / 不可 `409`（`plain_kernel_mode`・`no_checkpoint_file`・`exception`）/ `kernel_id` 不正 `404`・欠落 `400`・無認証 `403`・タイムアウト `504`。

> 同一ホストにオーケストレーターがいる場合は、サーバー拡張なしで `jupyter_client` から control チャネルへ直接 `elastic_checkpoint_request` を送る運用も可能（control ハンドラは常に有効）。

## テスト

- **ユニット (11件追加, `tests/test_checkpoint_control.py`)**: `_save_checkpoint` / `_restore_checkpoint`（成功・plain-kernel・例外・ファイル無し）、control ハンドラの reply 送信、サーバー拡張の登録。全 79 passed / 16 skipped。
- **E2E (手動検証済み)**:
  - control 経路: 実カーネルを `jupyter_client` で起動 → セル実行 → control に `elastic_checkpoint_request` 送信 → `ok:true`・`checkpoint.pickle` 書き込み・restore も成功。
  - HTTP 全経路: 実 `jupyter server` 起動 → セッション作成 → `POST /elastic_kernel/checkpoint` で `200 ok:true`・ファイル書き込み確認、`/restore` も成功、ネガティブ（400/404/403）も期待通り。
- `black` / `isort` / `flake8` / `mypy` 全て clean。

## 補足（スコープ外の既存バグ）

E2E 中、`JPY_SESSION_NAME` 未設定で API 起動した場合に `__setup_file_path` がロガー設定前に `self.logger` を参照してクラッシュする**既存バグ**を確認（通常の JupyterLab 利用では `JPY_SESSION_NAME` が設定されるため踏まない）。本 PR のスコープ外として別途対応を推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)