### PR TITLE
fix: prevent kernel crash when JPY_SESSION_NAME is unset

### DIFF
--- a/elastic_kernel/kernel.py
+++ b/elastic_kernel/kernel.py
@@ -31,7 +31,13 @@ class ElasticKernel(IPythonKernel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.logger: logging.Logger
+        # __setup_file_path() 内のパス解決フォールバック
+        # (__resolve_path_without_jpy_session_name) は JPY_SESSION_NAME 未設定時に
+        # self.logger を参照する。これは __setup_logger() より前に実行されるため、
+        # ここで先に同名ロガーを取得しておかないと AttributeError でカーネルが即死する。
+        # __setup_logger() は同じ "ElasticKernelLogger" にファイルハンドラを設定するので、
+        # ここで取得したオブジェクトがそのまま後段で正しく構成される。
+        self.logger: logging.Logger = logging.getLogger("ElasticKernelLogger")
         self.log_file_path: str
         self.checkpoint_file_path: str
 


### PR DESCRIPTION
## 概要

`JPY_SESSION_NAME` が未設定の状態でカーネルが起動すると、**カーネルが `kernel_info` に応答する前に `AttributeError` で即死する**バグを修正する。

## 原因

`__init__` の処理順序:

```python
self.__setup_file_path()   # ← ここでロガーを参照してしまう
self.__setup_logger()      # self.logger が実際に設定されるのはここ
```

`__setup_file_path()` は `JPY_SESSION_NAME` 未設定時にフォールバックとして `__resolve_path_without_jpy_session_name()` を呼ぶが、このメソッドは `self.logger.debug(...)` を複数回使う。`self.logger` は `__setup_logger()`（後段）まで存在しない（`self.logger: logging.Logger` は型注釈のみで未代入）ため、`AttributeError: 'ElasticKernel' object has no attribute 'logger'` になる。

通常の JupyterLab でノートブックを開く利用では `JPY_SESSION_NAME` が設定されるためこの経路を踏まないが、`jupyter_client` から直接カーネルを起動する場合などで発現する。

## 修正

`__init__` 冒頭で先に名前付きロガーを取得しておく（1行）:

```python
self.logger: logging.Logger = logging.getLogger("ElasticKernelLogger")
```

`__setup_logger()` は同名 `"ElasticKernelLogger"` ロガーにファイルハンドラを設定する（`setup_logger` は冪等）。よってここで取得したオブジェクトがそのまま後段で正しく構成され、挙動は従来どおり。早期のフォールバック内 `debug` 呼び出しはハンドラ未設定の段階では実質 no-op となり、クラッシュしなくなる。

## 検証

- 再現/修正確認: `JPY_SESSION_NAME` を外して `jupyter_client` でカーネルを起動 → 修正前は `kernel_info` 応答前に死亡、修正後は正常に ready。
- `pytest`（68 passed / 16 skipped）、`black` / `flake8` / `mypy` 全て clean。

関連 Issue: #15（`JPY_SESSION_NAME` 未設定シナリオ）。本 PR はその経路でのクラッシュを解消するが、#15 本来のテーマ（リネーム後の検出）は別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)