### PR TITLE
ci: run test/coverage/format workflows only on code changes

### DIFF
--- a/.github/workflows/format-python-code.yml
+++ b/.github/workflows/format-python-code.yml
@@ -4,12 +4,22 @@ permissions:
   contents: write
 
 on:
+  # Python ファイルか整形設定(pyproject.toml)、このワークフロー自体が変わったときだけ走らせる。
+  # ドキュメントのみの変更では整形ジョブをスキップする。
   push:
     branches:
       - "main"
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - ".github/workflows/format-python-code.yml"
   pull_request:
     branches:
       - "main"
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - ".github/workflows/format-python-code.yml"
 
 jobs:
   auto-format:

--- a/.github/workflows/library-coverage.yml
+++ b/.github/workflows/library-coverage.yml
@@ -1,12 +1,30 @@
 name: Library coverage
 
 on:
+  # コード・テスト・依存・カバレッジ生成スクリプト・このワークフロー自体が変わったときだけ
+  # 走らせる。ドキュメントのみの変更ではスキップする（workflow_dispatch で手動実行は可能）。
   push:
     branches:
       - "main"
+    paths:
+      - "elastic_kernel/**"
+      - "elastic_notebook/**"
+      - "tests/**"
+      - "scripts/library_coverage.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/library-coverage.yml"
   pull_request:
     branches:
       - "main"
+    paths:
+      - "elastic_kernel/**"
+      - "elastic_notebook/**"
+      - "tests/**"
+      - "scripts/library_coverage.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/library-coverage.yml"
   workflow_dispatch:
 
 # Needed so the job can commit the regenerated coverage table back to the branch.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,28 @@
 name: Run tests
 
 on:
+  # コード・テスト・依存・このワークフロー自体が変わったときだけ走らせる。
+  # README/docs/CLAUDE.md などドキュメントのみの変更ではテストをスキップする。
   push:
     branches:
       - "main"
+    paths:
+      - "elastic_kernel/**"
+      - "elastic_notebook/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/test.yml"
   pull_request:
     branches:
       - "main"
+    paths:
+      - "elastic_kernel/**"
+      - "elastic_notebook/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/test.yml"
 
 jobs:
   test:


### PR DESCRIPTION
## 概要

テスト系の CI ワークフローを「適切なタイミングでのみ」走らせるよう、`paths` フィルタを追加する。**コード・テスト・依存・ワークフロー自体が変わったときだけ**実行し、README・docs・CLAUDE.md などドキュメントのみの変更ではスキップする。push(main) / PR(main) の両イベントは維持。

## 背景

現状 `test.yml`（5バージョン matrix の pytest）・`library-coverage.yml`・`format-python-code.yml` は main への push と PR の両方で**無条件に**発火していた。そのため CLAUDE.md や README だけの変更でも 5 バージョンのフルテストが走り、無駄が大きかった。

## 変更

| ワークフロー | 発火する paths |
| --- | --- |
| `test.yml` | `elastic_kernel/**` `elastic_notebook/**` `tests/**` `pyproject.toml` `uv.lock` + 自ファイル |
| `library-coverage.yml` | 上記 + `scripts/library_coverage.py`（`workflow_dispatch` は維持） |
| `format-python-code.yml` | `**/*.py` `pyproject.toml` + 自ファイル |

## 安全性

- `main` に required status check は設定されていない（確認済み）ため、docs のみ変更の PR でテストがスキップされてもマージはブロックされない。
- ワークフロー自体のパスを含めているので、トリガー設定を今後変更したときはそのコミットで再実行される。
- 3ファイルとも YAML パース検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)